### PR TITLE
Issue/31 link to previous scenarios

### DIFF
--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -25,6 +25,7 @@ import { schema } from './validation/schema'
 import { setEpidemiologicalData, setPopulationData, setSimulationData } from './state/actions'
 import { scenarioReducer } from './state/reducer'
 import { defaultScenarioState } from './state/state'
+import { serializeScenarioToURL, deserializeScenarioFromURL } from './state/URLSerializer'
 
 import { ResultsCard } from './Results/ResultsCard'
 import { ScenarioCard } from './Scenario/ScenarioCard'
@@ -44,7 +45,11 @@ const severityDefaults: SeverityTableRow[] = updateSeverityTable(severityData)
 
 function Main() {
   const [result, setResult] = useState<AlgorithmResult | undefined>()
-  const [scenarioState, scenarioDispatch] = useReducer(scenarioReducer, defaultScenarioState /* , initDefaultState */)
+  const [scenarioState, scenarioDispatch] = useReducer(
+    scenarioReducer,
+    defaultScenarioState,
+    deserializeScenarioFromURL,
+  )
 
   // TODO: Can this complex state be handled by formik too?
   const [severity, setSeverity] = useState<SeverityTableRow[]>(severityDefaults)
@@ -84,6 +89,7 @@ function Main() {
     const caseCounts      = countryCaseCounts[scenarioState.population.data.cases] || []
     const containmentData = scenarioState.containment.data.reduction
 
+    serializeScenarioToURL(scenarioState, params)
     const newResult = await run(paramsFlat, severity, ageDistribution, containmentData)
 
     setResult(newResult)

--- a/src/components/Main/state/URLSerializer.ts
+++ b/src/components/Main/state/URLSerializer.ts
@@ -1,0 +1,71 @@
+import { AllParams } from '../../../algorithms/Param.types'
+import { State } from './state'
+
+/*
+
+Quick and dirty helper to serialize/deserialize parameters within the URL, 
+so people can share/save it and keep their parameters
+
+This could have been done inside a redux middleware, but with some refacto.
+
+We use JSON.stringify to serialize things out. It's not the most optimized way at all,
+but it works, and it's simple enough. Note that Date object is serialized as a string,
+so some extra work is needed during deserialization.
+
+*/
+
+export async function serializeScenarioToURL(scenarioState: State, params: AllParams) {
+  const toSave = {
+    ...params,
+    current: {
+      overall: scenarioState.overall.current,
+      population: scenarioState.population.current,
+      epidemiological: scenarioState.epidemiological.current,
+      containment: scenarioState.containment.current,
+    },
+    containment: scenarioState.containment.data.reduction,
+  }
+
+  window.history.pushState('', '', `?${encodeURIComponent(JSON.stringify(toSave))}`)
+}
+
+export function deserializeScenarioFromURL(initState: State) {
+  if (window.location.search) {
+    try {
+      /*
+        We deserialise the URL by removing the first char ('?'), and applying JSON.parse 
+      */
+      const obj = JSON.parse(decodeURIComponent(window.location.search.slice(1)))
+
+      // Be careful of dates object that have been serialized to string
+
+      // safe to mutate here
+      obj.simulation.simulationTimeRange.tMin = new Date(obj.simulation.simulationTimeRange.tMin)
+      obj.simulation.simulationTimeRange.tMax = new Date(obj.simulation.simulationTimeRange.tMax)
+
+      const containmentDataReduction = obj.containment.map((c: { t: string; y: number }) => ({
+        y: c.y,
+        t: new Date(c.t),
+      }))
+      return {
+        ...initState,
+        overall: { ...initState.overall, current: obj.current.overall },
+        population: { ...initState.population, current: obj.current.population, data: obj.population },
+        epidemiological: {
+          ...initState.epidemiological,
+          current: obj.current.epidemiological,
+          data: obj.epidemiological,
+        },
+        containment: {
+          ...initState.containment,
+          current: obj.current.containment,
+          data: { reduction: containmentDataReduction },
+        },
+        simulation: { ...initState.simulation, data: obj.simulation },
+      }
+    } catch (error) {
+      console.error('Error while parsing URL :', error.message)
+    }
+  }
+  return initState
+}


### PR DESCRIPTION
I've added a quick and dirty helper to serialize/deserialize parameters within the URL, 
so people can share/save it and keep their parameters.

I haven't tested it that much, but it seems to work okay.

Note: the "custom" labels are not correctly displayed within the drop downs, but I don't think that's an issue.

This could have been done inside a redux middleware, but with some refacto.

We use JSON.stringify to serialize things out. It's not the most optimised way at all,
but it works, and it's simple enough. Note that Date object is serialized as a string,
so some extra work is needed during deserialization.

* We serialize the parameters and update the URL when clicking on `run`

* We deserialize it using the "init" parameter of the useReducer hook function.

(If nothing is passed in the URL, then the default initScenario is set, or if something bad is passed in the URL, the same (with a catched error))