### PR TITLE
Fix navbar home link

### DIFF
--- a/src/components/Layout/NavigationBar.tsx
+++ b/src/components/Layout/NavigationBar.tsx
@@ -1,10 +1,12 @@
 import React from 'react'
 
-import { RouteComponentProps, withRouter } from 'react-router-dom'
+import { RouteComponentProps, withRouter, Link } from 'react-router-dom';
 
 import NavigationLink from './NavigationLink'
 
 import logo from '../../assets/img/HIVEVO_logo.png'
+import { HomePath } from '../../routes'
+
 import './NavigationBar.scss'
 
 export interface NavLinkMap {
@@ -18,9 +20,9 @@ export interface NavigationBarProps extends RouteComponentProps<{}> {
 function NavigationBar({ navLinks, location }: NavigationBarProps) {
   return (
     <nav className="navbar navbar-expand navbar-dark bg-dark" role="navigation">
-      <a className="navbar-brand" href="/">
+      <Link className="navbar-brand" to={HomePath}>
         <img className="navbar-brand-image" alt="logo" src={logo} />
-      </a>
+      </Link>
 
       <ul className="navbar-nav">
         {Object.entries(navLinks).map(([url, text]) => {

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,7 +1,9 @@
 import { PageRouteDesc } from './components/PageSwitcher/PageSwitcher'
 
+export const HomePath = '/covid19/'
+
 const routes: PageRouteDesc[] = [
-  { path: '/covid19/', page: 'Home' },
+  { path: HomePath, page: 'Home' },
   { path: '/covid19/about', page: 'About' },
   { path: '/covid19/team', page: 'Team' },
 ]


### PR DESCRIPTION
Replace navbar brand logo href with Link pointing to the root /covid19 page.

The previous behavior navigated the app to http://localhost:3000/, which gives a "Cannot GET /" error
since webpack is serving the root page from http://localhost:3000/covid19/.