### PR TITLE
Added open source contrib templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,22 +20,6 @@ Operative System:
 1.
 2.
 
-<!--
-  Your bug will get fixed much faster if we can run your code and it doesn't
-  have dependencies other than React. Issues without reproduction steps or
-  code examples may be immediately closed as not actionable.
--->
-
-Link to code example:
-
-<!--
-  Please provide a CodeSandbox (https://codesandbox.io/s/new), a link to a
-  repository on GitHub, or provide a minimal code example that reproduces the
-  problem. You may provide a screenshot of the application if you think it is
-  relevant to your bug report. Here are some tips for providing a minimal
-  example: https://stackoverflow.com/help/mcve.
--->
-
 ## The current behavior
 
 <!--

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,50 @@
+---
+name: "Bug Report"
+about: Report a reproducible bug.
+title: '[Bug] '
+labels: 'severity:bug'
+
+---
+
+<!--
+  Please provide a clear and concise description of what the bug is. Include
+  screenshots if needed. Please test using the latest version of the application
+  to make sure the issue has not already been fixed.
+-->
+
+Browser (include version):
+Operative System:
+
+## Steps To Reproduce
+
+1.
+2.
+
+<!--
+  Your bug will get fixed much faster if we can run your code and it doesn't
+  have dependencies other than React. Issues without reproduction steps or
+  code examples may be immediately closed as not actionable.
+-->
+
+Link to code example:
+
+<!--
+  Please provide a CodeSandbox (https://codesandbox.io/s/new), a link to a
+  repository on GitHub, or provide a minimal code example that reproduces the
+  problem. You may provide a screenshot of the application if you think it is
+  relevant to your bug report. Here are some tips for providing a minimal
+  example: https://stackoverflow.com/help/mcve.
+-->
+
+## The current behavior
+
+<!--
+  Provide an accurate description of the problem
+-->
+
+
+## The expected behavior
+
+<!--
+  Describe how the application should be behaving once the bug is fixed.
+-->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Questions, discussions
+    url: https://github.com/neherlab/covid19_scenarios/issues/18
+    about: This thread is dedicated to questions and discussions about the "COVID-19 scenarios" application as well as the science behind it.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+
+## Description
+
+<!-- 
+    A few sentences describing the overall goals of the pull request's commits.
+-->
+
+## Related issues
+
+<!--
+    List related issues:
+       - Fixes https://github.com/neherlab/covid19_scenarios/issues/xy
+       - Contributes to https://github.com/neherlab/covid19_scenarios/issues/yz
+-->
+
+## Impacted Areas in the application
+
+<!--
+    List general components or areas of the application that this PR will affect.
+-->
+
+## Testing
+
+<!-- 
+    Outline the steps to test the changes proposed by this PR.
+-->
+
+## Deploy Notes
+<!-- 
+    Notes regarding specific deployment requirements for this PR, such as DB updates, migrations, etc.
+-->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at [atom@github.com](mailto:atom@github.com). All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [https://contributor-covenant.org/version/1/4][version]
+
+[homepage]: https://contributor-covenant.org
+[version]: https://contributor-covenant.org/version/1/4/

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at [atom@github.com](mailto:atom@github.com). All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,5 +15,5 @@ code. Unacceptable behavior won't be tolerated.
 ## Reporting Bugs
 
 When you are creating a bug report, please include as many details as possible. Fill out
-[the required template](https://github.com/atom/.github/blob/master/.github/ISSUE_TEMPLATE/bug_report.md), 
+[the required template](https://github.com/neherlab/covid19_scenarios/blob/master/.github/ISSUE_TEMPLATE/bug_report.md), 
 the information it asks for helps us resolve issues faster.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# Contributing 
+
+Thanks for taking the time to contribute. There is a dedicated thread to questions and 
+discussions about the "COVID-19 scenarios" application as well as the science behind 
+it: https://github.com/neherlab/covid19_scenarios/issues/18
+
+
+## Code of Conduct
+
+This project and everyone participating in it is governed by the 
+[Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this 
+code. Unacceptable behavior won't be tolerated.
+
+
+## Reporting Bugs
+
+When you are creating a bug report, please include as many details as possible. Fill out
+[the required template](https://github.com/atom/.github/blob/master/.github/ISSUE_TEMPLATE/bug_report.md), 
+the information it asks for helps us resolve issues faster.


### PR DESCRIPTION
Contributes to https://github.com/neherlab/covid19_scenarios/issues/16.

The following templates are added:
 - Issue templates: template for bug reports and configuration allowing the creation of blank issues ([github docs](https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository))
- Basic PR template
- Basic contribution guidelines
- Code of Conduct: https://www.contributor-covenant.org/