### PR TITLE
change aspect ratio of graphs on narrow screens and clamp at minimcal…

### DIFF
--- a/src/components/Main/Results/AgeBarChart.tsx
+++ b/src/components/Main/Results/AgeBarChart.tsx
@@ -41,7 +41,7 @@ export function AgeBarChart({ data, rates }: SimProps) {
             return <div className="w-100 h-100" />
           }
 
-          const height = width / ASPECT_RATIO
+          const height = Math.max(250, width / ASPECT_RATIO)
 
           return (
             <>
@@ -60,7 +60,7 @@ export function AgeBarChart({ data, rates }: SimProps) {
                 <XAxis dataKey="name" />
                 <YAxis label={{ value: 'Cases', angle: -90, position: 'insideLeft' }} />
                 <Tooltip />
-                <Legend verticalAlign="top" />
+                <Legend verticalAlign="top"/>
                 <CartesianGrid strokeDasharray="3 3" />
                 <Bar dataKey="peakSevere" fill={colors.severe} name="peak severe" />
                 <Bar dataKey="peakCritical" fill={colors.critical} name="peak critical" />

--- a/src/components/Main/Results/DeterministicLinePlot.tsx
+++ b/src/components/Main/Results/DeterministicLinePlot.tsx
@@ -145,7 +145,7 @@ export function DeterministicLinePlot({ data, userResult, logScale, caseCounts }
             return <div className="w-100 h-100" />
           }
 
-          const height = width / ASPECT_RATIO
+          const height = Math.max(500, width / ASPECT_RATIO)
 
           return (
             <>


### PR DESCRIPTION
This PR addressed issue #15 in an ad-hoc way. The main problem with rendering on mobile was that all space got allocated to the legend pushing graph height to zero. This now limits the minimal graph height from below. Not ideal, but should improve the display in most situations.