### PR TITLE
#19 Fix silent failure of 'should work for a lot of countries'.

### DIFF
--- a/src/algorithms/run.test.tsx
+++ b/src/algorithms/run.test.tsx
@@ -78,22 +78,24 @@ describe('run()', () => {
     const results: Record<string, any> = {}
 
     for (let country of countries) {
-      try {
-        const countryAgeDistributionWithType = countryAgeDistribution as Record<string, any>
-        const result = await run(
-          {
-            ...populationScenarios.filter(p => p.name === country)[0].data,
-            ...epidemiologicalScenarios[1].data,
-            ...simulationData,
-          },
-          severityData,
-          countryAgeDistributionWithType[country],
-          containmentScenarios[3].data.reduction,
-        )
-        results[country] = result
-      } catch (e) {
-        console.error(e)
-      }
+      const countryAgeDistributionWithType = countryAgeDistribution as Record<string, any>
+      const populationScenario = populationScenarios.find(p => p.name === country);
+
+      // Confirm that the populationScenario is defined, because
+      // then we can safely apply the "! - Non-null assertion operator"
+      expect(populationScenario).toBeDefined()
+
+      const result = await run(
+        {
+          ...populationScenario!.data,
+          ...epidemiologicalScenarios[1].data,
+          ...simulationData,
+        },
+        severityData,
+        countryAgeDistributionWithType[populationScenario!.data.country],
+        containmentScenarios[3].data.reduction,
+      )
+      results[country] = result
     }
     let attributes = [...countries, 'deterministicTrajectory', 'time', 'total', 'infectious']
   })


### PR DESCRIPTION
This PR is part of a larger issue, described by #19.

It addresses a specific test named "should work for a lot of countries". It was failing because it used the wrong Country Name key to look up Population Scenario and Country Age Distribution. The failure was masked because the test was wrapped in a try/catch.

This PR fixes the test and removes try/catch.