### PR TITLE
Prevent having button inside button on CollapsibleCard-CardHeader

### DIFF
--- a/src/components/Form/CollapsibleCard.tsx
+++ b/src/components/Form/CollapsibleCard.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 
 import { MdArrowDropDown } from 'react-icons/md'
-import { Button, Card, CardBody, CardHeader, Collapse } from 'reactstrap'
+import { Card, CardBody, CardHeader, Collapse } from 'reactstrap'
 
 import HelpLabel from './HelpLabel'
 
@@ -19,15 +19,15 @@ export function CollapsibleCard({ identifier, title, help, children, defaultColl
 
   return (
     <Card className="h-100">
-      <CardHeader>
-        <Button className="w-100 h-100 text-left p-0" type="button" color="default" onClick={toggle}>
+      <CardHeader onClick={toggle}>
+        <div className="w-100 h-100 text-left p-0" color="default">
           <div className="d-flex">
             <span className="mx-1 my-auto">
               <MdArrowDropDown size={30} className={`${collapsed ? 'icon-rotate-90' : 'icon-rotate-0'}`} />
             </span>
             <HelpLabel identifier={identifier} label={title} help={help} />
           </div>
-        </Button>
+        </div>
       </CardHeader>
 
       <Collapse isOpen={!collapsed}>


### PR DESCRIPTION
Not a big change but its the first thing I realized when running the project, the console complained about html validation as <button> can not contain <button> inside.

![button inside button](https://user-images.githubusercontent.com/23552631/77200936-e2041a80-6aeb-11ea-8e82-e572d98222be.png)

This PR solves that while keeping the same design and functionality at the CollapsibleCard CardHeader