### PR TITLE
added aspect ratio and conditon for mobile layout in mitgation graph

### DIFF
--- a/src/components/Main/Containment/ContainmentGraph.tsx
+++ b/src/components/Main/Containment/ContainmentGraph.tsx
@@ -6,6 +6,7 @@ import ReactResizeDetector from 'react-resize-detector'
 import { TimeSeries } from '../../../algorithms/TimeSeries'
 
 const ASPECT_RATIO = 16 / 9
+const MOBILE_ASPECT_RATIO = 4 / 5
 const MAX_TRANSMISSION_RATIO = 1.2
 
 export interface DrawParams {
@@ -236,7 +237,7 @@ export function ContainmentGraphImpl({ data, onDataChange, width, height }: Cont
             return <div className="w-100 h-100" />
           }
 
-          const height = width / ASPECT_RATIO
+          const height = width < 500 ? width / MOBILE_ASPECT_RATIO : width / ASPECT_RATIO
 
           return (
             <svg className="noselect" width={width} height={height} viewBox={`0 0 ${width} ${height}`} ref={d3ref} />
@@ -261,7 +262,7 @@ export function ContainmentGraph({ data, onDataChange }: ContainmentGraphProps) 
             return <div className="w-100 h-100" />
           }
 
-          const height = width / ASPECT_RATIO
+          const height = width < 500 ? width / MOBILE_ASPECT_RATIO : width / ASPECT_RATIO
 
           return <ContainmentGraphImpl data={data} onDataChange={onDataChange} width={width} height={height} />
         }}


### PR DESCRIPTION
## Description

Fixes the y-axis text overlapping issue for mobile devices. 

## Related issues
Fixes https://github.com/neherlab/covid19_scenarios/issues/78
Contributes to https://github.com/neherlab/covid19_scenarios/issues/71


## Impacted Areas in the application

This creates a 4 / 5 mobile ratio inside the containmentGraph component. A  ternary operator is implemented to handle the ratio swtich 

## Testing

<!-- 
    Outline the steps to test the changes proposed by this PR.
-->

## Deploy Notes
<!-- 
    Notes regarding specific deployment requirements for this PR, such as DB updates, migrations, etc.
-->
