### PR TITLE
fix: do not re-render Mitigration graph unnecessarily

### DIFF
--- a/src/components/Main/Containment/ContainmentGraph.tsx
+++ b/src/components/Main/Containment/ContainmentGraph.tsx
@@ -17,6 +17,9 @@ export interface DrawParams {
 }
 
 function draw({ data, width, height, onDataChange, d3ref }: DrawParams) {
+  if (d3ref.current === null) {
+    return
+  }
   const newData = data.map(d => {
     return { t: d.t, y: d.y }
   }) // copy
@@ -225,8 +228,7 @@ export interface ContainmentGraphImplProps {
 export function ContainmentGraphImpl({ data, onDataChange, width, height }: ContainmentGraphImplProps) {
   const d3ref = useRef<SVGSVGElement>(null)
 
-  // FIXME: can we avoid some of the re-rendering? Add array of dependencies. Ensure proper cleanups.
-  useEffect(() => draw({ data, onDataChange, width, height, d3ref }))
+  useEffect(() => draw({ data, onDataChange, width, height, d3ref }), [data, width, height, d3ref.current])
 
   return (
     <div className="w-100 h-100">


### PR DESCRIPTION
Previously the graph was being re-rendered on every
event, which caused problems when trying to drag a
graph vertex at the same time as de-focussing another
input element.

Now the graph is only rendered initially, and then when
either the graph data changes, or the graph is resized.

Fixes #72


## Description

<!-- 
    A few sentences describing the overall goals of the pull request's commits.
-->

## Related issues

<!--
    List related issues:
       - Fixes https://github.com/neherlab/covid19_scenarios/issues/xy
       - Contributes to https://github.com/neherlab/covid19_scenarios/issues/yz
-->

## Impacted Areas in the application

<!--
    List general components or areas of the application that this PR will affect.
-->

## Testing

<!-- 
    Outline the steps to test the changes proposed by this PR.
-->

## Deploy Notes
<!-- 
    Notes regarding specific deployment requirements for this PR, such as DB updates, migrations, etc.
-->
