### PR TITLE
Fix Calendar Alignment on Mobile

### DIFF
--- a/src/components/Form/FormDatePicker.tsx
+++ b/src/components/Form/FormDatePicker.tsx
@@ -10,6 +10,15 @@ import FormLabel from './FormLabel'
 
 import { DateRange } from '../../algorithms/Param.types'
 
+
+// Function to determine number of months to display on the datepicker.
+function getNumberOfMonthsCount(media: object) {
+  const { tiny, small, medium } = media
+  if (tiny) return 1
+  if (small) return 2
+  if (medium) return 3
+  return 4
+}
 export interface FormInputProps {
   identifier: string
   label: string
@@ -39,9 +48,9 @@ export function FormDatePicker({ identifier, label, help, allowPast = true }: Fo
                   }}
                 >
                   {media => {
-                    const { small, medium, large } = media
+                    const { small } = media
 
-                    const numberOfMonths = small ? 2 : medium ? 3 : 4
+                    const numberOfMonths = getNumberOfMonthsCount(media)
                     const orientation = small ? 'vertical' : 'horizontal'
                     const withPortal = small
 


### PR DESCRIPTION
## Description
Fixed the logic that decided the number of months that had to be rendered on mobile. Previously it was rendering 4. We have space only to render 1.

## Related issues
https://github.com/neherlab/covid19_scenarios/issues/71

## Impacted Areas in the application
Date Picker

