### PR TITLE
Add spectrum chat link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
-  - name: Questions, discussions
-    url: https://github.com/neherlab/covid19_scenarios/issues/18
-    about: This thread is dedicated to questions and discussions about the "COVID-19 scenarios" application as well as the science behind it.
+  - name: Ask a question
+    url: https://spectrum.chat/covid19-scenarios/general/questions-discussions~8d49f461-a890-4beb-84f7-2d6ed0ae503a
+    about: Ask questions and discuss with other community members

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,19 +1,21 @@
-# Contributing 
+# Contributing
 
-Thanks for taking the time to contribute. There is a dedicated thread to questions and 
-discussions about the "COVID-19 scenarios" application as well as the science behind 
-it: https://github.com/neherlab/covid19_scenarios/issues/18
+Thanks for taking the time to contribute. You can ask questions and discuss with other "COVID-19 scenarios" community
+members over the Spectrum chat:
 
+<p align="center">
+  <a href="https://spectrum.chat/covid19-scenarios/general/questions-discussions~8d49f461-a890-4beb-84f7-2d6ed0ae503a">
+    <img alt="Join the community on Spectrum" src="https://withspectrum.github.io/badge/badge.svg" />
+  </a>
+</p>
 
 ## Code of Conduct
 
-This project and everyone participating in it is governed by the 
-[Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this 
-code. Unacceptable behavior won't be tolerated.
-
+This project and everyone participating in it is governed by the [Code of Conduct](CODE_OF_CONDUCT.md). By
+participating, you are expected to uphold this code. Unacceptable behavior won't be tolerated.
 
 ## Reporting Bugs
 
 When you are creating a bug report, please include as many details as possible. Fill out
-[the required template](https://github.com/neherlab/covid19_scenarios/blob/master/.github/ISSUE_TEMPLATE/bug_report.md), 
+[the required template](https://github.com/neherlab/covid19_scenarios/blob/master/.github/ISSUE_TEMPLATE/bug_report.md),
 the information it asks for helps us resolve issues faster.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<h1 align="center">
+  COVID-19 Scenarios
+</h1>
+
 <p align="center">
   <a href="https://neherlab.org/covid19/">
     <img
@@ -8,10 +12,6 @@
     />
   </a>
 </p>
-
-<h1 align="center">
-  COVID-19 Scenarios
-</h1>
 
 <p align="center">
   <a href="https://neherlab.org/covid19/">
@@ -95,30 +95,19 @@
   </a>
 </p>
 
-
-
 <h2 align="center">
 Got questions or suggestions?
 </h2>
 
 <p align="center">
-  <a
-    alt="Link to join the chat"
-    href="https://spectrum.chat/covid19-scenarios/general/questions-discussions~8d49f461-a890-4beb-84f7-2d6ed0ae503a"
-  >
-    <img
-      alt="Image for the link to join the chat"
-      src="https://user-images.githubusercontent.com/9403403/77235704-691ec480-6bb8-11ea-985d-82ec87cfdcdf.png"
-    />
+  <a href="https://spectrum.chat/covid19-scenarios/general/questions-discussions~8d49f461-a890-4beb-84f7-2d6ed0ae503a">
+    <img alt="Join the community on Spectrum" src="https://withspectrum.github.io/badge/badge.svg" />
   </a>
 </p>
-
-
 
 <h2 align="center">
 Discover
 </h2>
-
 
 <p align="center" width="99%">
 <table width="100%">
@@ -185,32 +174,32 @@ Discover
 </table>
 </p>
 
-
 ### Overview
-This tool is based on an SIR model (see about page for details) that simulates a COVID19 outbreak.
-The population is initially mostly susceptible (other than for initial cases).
-Individuals that recover from COVID19 are subsequently immune.
-Currently, the parameters of the model are *not* fit to data but are simply defaults.
-These might fit better for some localities than others.
-In particular the initial cases counts are often only rough estimates.
 
-The primary purpose of the tool is to explore the dynamics of COVID19 cases and the associated strain on the health care system in the near future.
-The outbreak is influenced by infection control measures such as school closures, lock-down etc.
-The effect of such measures can be included in the simulation by adjusting the mitigation parameters.
-Analogously, you can explore the effect of isolation on specific age groups in the column "Isolated" in the table on severity assumptions and age specific isolation.
+This tool is based on an SIR model (see about page for details) that simulates a COVID19 outbreak. The population is
+initially mostly susceptible (other than for initial cases). Individuals that recover from COVID19 are subsequently
+immune. Currently, the parameters of the model are _not_ fit to data but are simply defaults. These might fit better for
+some localities than others. In particular the initial cases counts are often only rough estimates.
 
+The primary purpose of the tool is to explore the dynamics of COVID19 cases and the associated strain on the health care
+system in the near future. The outbreak is influenced by infection control measures such as school closures, lock-down
+etc. The effect of such measures can be included in the simulation by adjusting the mitigation parameters. Analogously,
+you can explore the effect of isolation on specific age groups in the column "Isolated" in the table on severity
+assumptions and age specific isolation.
 
 ### Parameters
+
 Parameters fall into three different categories
 
-  * population parameters
-  * epidemiological parameters
-  * clinical parameters
+- population parameters
+- epidemiological parameters
+- clinical parameters
 
 Most parameters can be adjusted in the tool and for many of them we provide presets.
 
-Input data for the tool and the basic parameters of the populations are collected in a separate repository [neherlab/covid19_scenarios_data](https://github.com/neherlab/covid19_scenarios_data).
-Please add data on populations and parsers of publicly available case count data there.
+Input data for the tool and the basic parameters of the populations are collected in a separate repository
+[neherlab/covid19_scenarios_data](https://github.com/neherlab/covid19_scenarios_data). Please add data on populations
+and parsers of publicly available case count data there.
 
 ### Development
 
@@ -224,18 +213,15 @@ Please add data on populations and parsers of publicly available case count data
 This will run the application in development mode (with hot reloading):
 
 ```bash
-
 git clone https://github.com/neherlab/covid19_scenarios
 cd covid19_scenarios/
 cp .env.example .env
 yarn install
 yarn dev
-
 ```
 
-This will trigger the development server and build process. Wait for the build
-to finish, then navigate to `http://localhost:3000` in a browser (last 5 version
-of Chrome or Firefox are supported in dev mode)
+This will trigger the development server and build process. Wait for the build to finish, then navigate to
+`http://localhost:3000` in a browser (last 5 version of Chrome or Firefox are supported in dev mode)
 
 Hit Ctrl+C in the terminal to shutdown.
 


### PR DESCRIPTION
## Description

This adds the Spectrum chat link to the new issue templates choose page and CONTRIBUTING.md file.

## Related issues

- Contributes to #16 
