### PR TITLE
Allow for browser sourcemaps when in dev mode

### DIFF
--- a/config/webpack/webpack.client.babel.ts
+++ b/config/webpack/webpack.client.babel.ts
@@ -354,7 +354,7 @@ export default {
       // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
       // @ts-ignore: BUG: This parameter is missing in @types/webpack declarations
       fileContext: 'web/content/sourcemaps',
-      noSources: true,
+      noSources: production,
     }),
 
     analyze &&


### PR DESCRIPTION
This PR addresses [this comment](https://github.com/neherlab/covid19_scenarios/issues/72#issuecomment-602071478) and allows for the proper generation of sourcemaps for an improved debugger experience in `development` mode (it's actually `!= production` because I thought this would be more future proof), which I found really useful for myself.
