### PR TITLE
[housekeeping] Fix list child key props in DeterministicLinePlot

### DIFF
--- a/src/components/Main/Results/DeterministicLinePlot.tsx
+++ b/src/components/Main/Results/DeterministicLinePlot.tsx
@@ -176,6 +176,7 @@ export function DeterministicLinePlot({ data, userResult, logScale, caseCounts }
                   linesToPlot.map(d => {
                     return (
                       <Line
+                        key={d.key}
                         dot={false}
                         isAnimationActive={false}
                         type='monotone'
@@ -192,6 +193,7 @@ export function DeterministicLinePlot({ data, userResult, logScale, caseCounts }
                   scatterToPlot.map(d => {
                     return (
                       <Scatter
+                        key={d.key}
                         dataKey={d.key}
                         fill={d.color}
                         name={d.name}


### PR DESCRIPTION
This PR simply addresses the `Warning: Each child in a list should have a unique "key" prop.` that are caused by the `<Line />` and `<Scatter />` lists in `DeterministicLinePlot`