### PR TITLE
[housekeeping] Fix LineProps['legendType'] type-safety with <Line />

### DIFF
--- a/src/components/Main/Results/DeterministicLinePlot.tsx
+++ b/src/components/Main/Results/DeterministicLinePlot.tsx
@@ -32,7 +32,7 @@ interface LineProps {
   key: string,
   name: string,
   color: string
-  legendType?: string
+  legendType?: import('recharts').LineProps['legendType']
 }
 
 function xTickFormatter(tick: string | number): string {
@@ -126,7 +126,7 @@ export function DeterministicLinePlot({ data, userResult, logScale, caseCounts }
       tMax = Math.max(tMax, observations[observations.length-1].time);
       plotData = plotData.concat(observations) //.filter((d) => {return d.time >= tMin && d.time <= tMax}))
       if (count_observations.observedDeaths){
-           scatterToPlot.push({key:'observedDeaths', 'color': colors.death, name: "Cumulative confirmed deaths"})
+        scatterToPlot.push({key:'observedDeaths', 'color': colors.death, name: "Cumulative confirmed deaths"})
       }
       if (count_observations.cases){
         scatterToPlot.push({key:'cases', 'color': colors.cumulativeCases, name: "Cumulative confirmed cases"})

--- a/src/components/Main/Results/DeterministicLinePlot.tsx
+++ b/src/components/Main/Results/DeterministicLinePlot.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import ReactResizeDetector from 'react-resize-detector'
 import { CartesianGrid, Legend, Line, ComposedChart, Scatter, Tooltip, TooltipPayload, XAxis, YAxis } from 'recharts'
+import type { LineProps as RechartsLineProps } from 'recharts'
 
 import { AlgorithmResult, UserResult } from '../../../algorithms/Result.types'
 import { EmpiricalData } from '../../../algorithms/Param.types'
@@ -32,7 +33,7 @@ interface LineProps {
   key: string,
   name: string,
   color: string
-  legendType?: import('recharts').LineProps['legendType']
+  legendType?: RechartsLineProps['legendType']
 }
 
 function xTickFormatter(tick: string | number): string {


### PR DESCRIPTION
This PR simply fixes the type error created by the `interface LineProps`' `legendType` conflicting with `rechart`'s `LineProps`' expected `legendType`s, which are comprised more specifically of string literals

<img width="841" alt="Screen Shot 2020-03-21 at 8 34 31 PM" src="https://user-images.githubusercontent.com/8883465/77239689-14794a80-6bb4-11ea-9c6e-8945220b4a7d.png">
