### PR TITLE
Fix crash when inputing number below 2 on ContainmentGraph

### DIFF
--- a/src/components/Form/FormSpinBox.tsx
+++ b/src/components/Form/FormSpinBox.tsx
@@ -35,6 +35,16 @@ export function FormSpinBox<T>({
   const showError = errorMessage && isTouched
   const borderDanger = showError ? 'border-danger' : ''
 
+  function validate(value) {
+    let error;
+    if (min && value < min) {
+      error = `The input cannot be less than ${min}`
+    } else if (max && value > max) {
+      error = `The input cannot be greater than ${max}` 
+    }
+    return error;
+  }
+
   return (
     <Field>
       {() => (
@@ -53,6 +63,7 @@ export function FormSpinBox<T>({
                 min={min}
                 max={max}
                 pattern={pattern}
+                validate={validate}
               />
               {showError ? <div className="text-danger">{errorMessage}</div> : null}
             </Col>

--- a/src/components/Main/Containment/ContainmentGraph.tsx
+++ b/src/components/Main/Containment/ContainmentGraph.tsx
@@ -21,8 +21,9 @@ function draw({ data, width, height, onDataChange, d3ref }: DrawParams) {
   const newData = data.map(d => {
     return { t: d.t, y: d.y }
   }) // copy
-  const tMin = data[0].t
-  const tMax = data[data.length - 1].t
+
+  const tMin = data[0] && data[0].t
+  const tMax = data[0] && data[data.length - 1].t
   const svg = d3ref.current
 
   const margin = {

--- a/src/components/Main/Scenario/ScenarioCardContainment.tsx
+++ b/src/components/Main/Scenario/ScenarioCardContainment.tsx
@@ -47,6 +47,7 @@ function ScenarioCardContainment({ scenarioState, errors, touched, scenarioDispa
         help="Number of controllable points on the mitigation curve"
         step={1}
         min={2}
+        max={100}
         errors={errors}
         touched={touched}
       />


### PR DESCRIPTION
## Description

If you go onto the "Transmission rel to baseline" graph, and type an "invalid" number (ie below 2), the whole page crashes. This stops the page from crashing.

If you enter a number too high (10,000), the page also crashes. This throws a warning in that scenario once the numbers get higher than 100, but doesn't stop user behavior. (Would be nice!)

I probably won't get to it into this diff, but if you bring the number to 1 and then back to 10, the y values of the graph are lost seemingly until you refresh. I don't really know why this is.

## Related issues

None

## Impacted Areas in the application

Just that one graph, as far as I know!

## Testing

Manual.

## Deploy Notes

N/A
