### PR TITLE
Scroll ResultsCard into view when "Run" is tapped

### DIFF
--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -32,6 +32,7 @@ import { ScenarioCard } from './Scenario/ScenarioCard'
 import { updateSeverityTable } from './Scenario/severityTableUpdate'
 
 import './Main.scss'
+import { useScrollIntoView } from '../../helpers/hooks'
 
 export function severityTableIsValid(severity: SeverityTableRow[]) {
   return !severity.some(row => _.values(row?.errors).some(x => x !== undefined))
@@ -112,7 +113,20 @@ function Main() {
           onSubmit={handleSubmit}
           validate={setScenarioToCustom}
         >
-          {({ errors, touched, isValid }) => {
+          {({ errors, touched, isValid, isSubmitting }) => {
+            /**
+             * viewport width - we only want to scroll the ResultsCard into view if viewing on mobile devices, where the layout is only a single column
+             * @see {@link https://stackoverflow.com/a/8876069/3942699}
+             */
+            const vw = Math.max(document.documentElement.clientWidth, window.innerWidth || 0)
+            /**
+             * 992 is the width at which the layout collapses into a single column
+             * @see {@tutorial https://getbootstrap.com/docs/4.0/layout/overview/#responsive-breakpoints}
+             * 
+             * only `scrollIntoView` when `isSubmitting` goes from `true` -> `false`
+             */
+            const refOfElementToScrollIntoView = useScrollIntoView<HTMLDivElement>(!isSubmitting && (vw < 992))
+
             const canRun = isValid && severityTableIsValid(severity)
 
             return (
@@ -130,7 +144,9 @@ function Main() {
                   </Col>
 
                   <Col lg={8} xl={6} className="py-1 px-1">
-                    <ResultsCard canRun={canRun} severity={severity} result={result} caseCounts={empiricalCases}/>
+                    <div ref={refOfElementToScrollIntoView}>
+                      <ResultsCard canRun={canRun} severity={severity} result={result} caseCounts={empiricalCases}/>
+                    </div>
                   </Col>
                 </Row>
               </Form>

--- a/src/components/Main/Results/ResultsCard.tsx
+++ b/src/components/Main/Results/ResultsCard.tsx
@@ -25,19 +25,6 @@ import { OutcomeRatesTable } from './OutcomeRatesTable'
 
 import { useTranslation } from 'react-i18next'
 
-function scrollToViewGraphs(result: object) {
-  // Should run only in mobile and also only if result is not found.
-  if (result || window.screen.width > 600) return
-  // Time taken to render the graphs depends on deterministicTrajectory and 0.8s second seems like a fair waittime. Also, top: 550 is a temporary fix..
-  setTimeout(() => {
-    window.scrollBy({
-      top: 550,
-      left: 0,
-      behavior: 'smooth'
-    })
-  }, 800)
-}
-
 export interface ResutsCardProps {
   canRun: boolean
   severity: SeverityTableRow[] // TODO: pass severity throughout the algorithm and as a part of `AlgorithmResult` instead?
@@ -98,7 +85,6 @@ function ResultsCard({ canRun, severity, result, caseCounts }: ResutsCardProps) 
                 color="primary"
                 disabled={!canRun}
                 data-testid="RunResults"
-                onClick={scrollToViewGraphs.bind(this, result)}
               >
                 {t('Run')}
               </Button>

--- a/src/helpers/hooks.ts
+++ b/src/helpers/hooks.ts
@@ -1,0 +1,32 @@
+import { useEffect, useRef } from "react";
+
+/** @see {@tutorial https://stackoverflow.com/questions/53446020/how-to-compare-oldvalues-and-newvalues-on-react-hooks-useeffect} */
+export const usePrevious = <T>(value: T) => {
+  const ref = useRef<T>();
+  useEffect(() => {
+    ref.current = value;
+  });
+  return ref.current;
+};
+
+export const useScrollIntoView = <T extends HTMLElement = any>(trigger: any) => {
+  const refOfElementToScrollIntoView = useRef<T>(null)
+
+  /**
+   * when the trigger transitions from "off" to "on" (e.g. the data was initialized)
+   * scroll the designated element (refOfElementToScrollIntoView) into view
+   */
+  const previousTrigger = usePrevious(trigger)
+
+  useEffect(() => {
+    trigger && !previousTrigger && setTimeout(() => {
+      /**
+       * scroll the viewport down to the point where the top of this element is at the top of the viewport
+       * @see {@tutorial https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView}
+       */
+      refOfElementToScrollIntoView.current?.scrollIntoView({ behavior: 'smooth', block: 'start', inline: 'nearest' })
+    })
+  }, [trigger])
+
+  return refOfElementToScrollIntoView
+}


### PR DESCRIPTION
This PR addresses the "Tapping 'Run' button gives no clue that there is more content appeared below" task in https://github.com/neherlab/covid19_scenarios/issues/71. Specifically, it uses a `div` wrapper around `ResultsCard` (I would've preferred to use the `Col` that already wrapped it, but getting a `ref` out of reactstrap components proved too difficult) to [`scrollIntoView(alignToTop)`](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView).

It also:
- ensures that the auto-scrolling is only triggered when on a mobile layout wherein the form layout is constrained to a single column
- attempts to use [`scroll-behavior: smooth`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-behavior) (even though it isn't supported in Safari or IE, but it's better than nothing imo), and resets `scroll-behavior` back to whatever it was after this transition
- adds a `src/helpers/hooks.ts` as a location for storing some custom hooks which have been used for this feature. all are welcome to reuse them if they'd so please