### PR TITLE
Add favicon, increase size for range selector.

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -7,6 +7,21 @@
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
+
+    <!-- Favicon -->
+    <link rel="apple-touch-icon" sizes="57x57" href="/images/favicons/apple-icon-57x57.png">
+    <link rel="apple-touch-icon" sizes="60x60" href="/images/favicons/apple-icon-60x60.png">
+    <link rel="apple-touch-icon" sizes="72x72" href="/images/favicons/apple-icon-72x72.png">
+    <link rel="apple-touch-icon" sizes="76x76" href="/images/favicons/apple-icon-76x76.png">
+    <link rel="apple-touch-icon" sizes="114x114" href="/images/favicons/apple-icon-114x114.png">
+    <link rel="apple-touch-icon" sizes="120x120" href="/images/favicons/apple-icon-120x120.png">
+    <link rel="apple-touch-icon" sizes="144x144" href="/images/favicons/apple-icon-144x144.png">
+    <link rel="apple-touch-icon" sizes="152x152" href="/images/favicons/apple-icon-152x152.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="/images/favicons/apple-icon-180x180.png">
+    <link rel="icon" type="image/png" sizes="192x192" href="/images/favicons/android-icon-192x192.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="/images/favicons/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="96x96" href="/images/favicons/favicon-96x96.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/images/favicons/favicon-16x16.png">
   </head>
   <body>
     <div id="root"></div>

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -86,6 +86,17 @@ p {
 input[type='number']::-webkit-inner-spin-button,
 input[type='number']::-webkit-outer-spin-button {
   opacity: 1;
+  
+}
+
+.form-group {
+  input[type='number']::-webkit-inner-spin-button,
+  input[type='number']::-webkit-outer-spin-button {
+    position: relative;
+    right: -28px;
+    width: 40px;
+    height: 40px;
+  }
 }
 
 .noselect {


### PR DESCRIPTION
Description
Add favicon for the application. (Uses the same as that of the parent domain). After this change favicons won't work locally but I guess that's no big deal.
Increase the size of input type number thereby giving users more room to click. I do it only for the first fold and not for Severity Assumptions as there's no room if the input exceeds a certain value. Hence the CSS scoping.

<img width="665" alt="number-size-increase" src="https://user-images.githubusercontent.com/12910216/77243512-dc641d00-6c30-11ea-8e8b-f7ec0ae429b0.png">

Impacted Areas in the application
Favicon
Forms