### PR TITLE
fix AllParams import path and convert to type import in URLSerializer

### DIFF
--- a/src/components/Main/state/URLSerializer.ts
+++ b/src/components/Main/state/URLSerializer.ts
@@ -1,4 +1,4 @@
-import { AllParams } from '../../../algorithms/Param.types'
+import type { AllParams } from '../../../algorithms/types/Param.types'
 import { State } from './state'
 
 /*


### PR DESCRIPTION
## Description

Fix `AllParams` import path and convert to type import in `URLSerializer`

## Related issues

https://github.com/neherlab/covid19_scenarios/issues/101

