### PR TITLE
fix SeverityTable <TableHeaderRow cellComponent={HeaderCell} /> type …

### DIFF
--- a/src/components/Main/Scenario/SeverityTable.tsx
+++ b/src/components/Main/Scenario/SeverityTable.tsx
@@ -36,7 +36,7 @@ const columnColors = {
 
 const getRowId = (row: TableRow) => row.id
 
-export type HeaderCellProps = TableBase.DataCellProps
+export type HeaderCellProps = Partial<TableBase.DataCellProps> & TableHeaderRow.CellProps
 
 export function HeaderCell({ column, ...restProps }: HeaderCellProps) {
   const { title } = column


### PR DESCRIPTION
## Description

```
src/components/Main/Scenario/SeverityTable.tsx:193:29 - error TS2322: Type '({ column, ...restProps }: DataCellProps) => Element' is not assignable to type 'ComponentClass<CellProps, any> | FunctionComponent<CellProps> | undefined'.
  Type '({ column, ...restProps }: DataCellProps) => Element' is not assignable to type 'FunctionComponent<CellProps>'.
    Types of parameters '__0' and 'props' are incompatible.
      Type 'PropsWithChildren<CellProps>' is missing the following properties from type 'DataCellProps': value, row

193             <TableHeaderRow cellComponent={HeaderCell} />
                                ~~~~~~~~~~~~~

  node_modules/@devexpress/dx-react-grid-bootstrap4/dist/dx-react-grid-bootstrap4.d.ts:770:3
    770   cellComponent?: React.ComponentType<TableHeaderRowBase.CellProps>;
          ~~~~~~~~~~~~~
    The expected type comes from property 'cellComponent' which is declared here on type 'IntrinsicAttributes & TableHeaderRowProps & { children?: ReactNode; }'
```

## Related issues

#101 
