### PR TITLE
fix(form): make form help button align with input label

### DIFF
--- a/src/components/Form/HelpLabel.tsx
+++ b/src/components/Form/HelpLabel.tsx
@@ -10,10 +10,8 @@ export interface HelpLabelProps {
 
 export default function HelpLabel({ identifier, label, help }: HelpLabelProps) {
   return (
-    <div className="d-flex">
-      <span className="my-auto">
-        <FormHelpButton identifier={`${identifier}_help`} label={label} help={help} />
-      </span>
+    <div className="d-flex align-items-center">
+      <FormHelpButton identifier={`${identifier}_help`} label={label} help={help} />
       <span className="ml-2 my-auto text-truncate">{label}</span>
     </div>
   )


### PR DESCRIPTION
## Description

Hello, I noticed that the ? icon was slightly misaligned with the form label so I decided to take a look.

## Related issues

## Impacted Areas in the application

The header of the different sections and the form fields

## Testing

I compared how it looks in mobile and desktop viewports and it looks good

### Before

![before](https://user-images.githubusercontent.com/18427801/77260982-72c52c80-6c8b-11ea-9019-f5b4955e44fc.png)

### After

![after](https://user-images.githubusercontent.com/18427801/77260984-75c01d00-6c8b-11ea-88f0-4d409301866f.png)
