### PR TITLE
Add localizedNumber, format labels on Y Axis of DeterministicLinePlot

### DIFF
--- a/package.json
+++ b/package.json
@@ -246,7 +246,7 @@
     "postcss-loader": "3.0.0",
     "postcss-preset-env": "6.7.0",
     "preload-webpack-plugin": "3.0.0-beta.4",
-    "prettier": "1.19.1",
+    "prettier": "2.0.1",
     "promise-timeout": "1.3.0",
     "purgecss-webpack-plugin": "2.1.0",
     "react-dropzone": "10.2.1",

--- a/src/components/Main/Results/DeterministicLinePlot.tsx
+++ b/src/components/Main/Results/DeterministicLinePlot.tsx
@@ -3,10 +3,9 @@ import ReactResizeDetector from 'react-resize-detector'
 import { CartesianGrid, Legend, Line, ComposedChart, Scatter, Tooltip, TooltipPayload, XAxis, YAxis } from 'recharts'
 import type { LineProps as RechartsLineProps } from 'recharts'
 
+import { useTranslation } from 'react-i18next'
 import { AlgorithmResult, UserResult } from '../../../algorithms/types/Result.types'
 import { EmpiricalData } from '../../../algorithms/types/Param.types'
-
-import { useTranslation } from 'react-i18next'
 
 const ASPECT_RATIO = 16 / 9
 
@@ -21,7 +20,7 @@ export const colors = {
   cumulativeCases: '#aaaaaa',
   newCases: '#fdbf6f',
   hospitalBeds: '#bbbbbb',
-  ICUbeds: '#cccccc'
+  ICUbeds: '#cccccc',
 }
 
 export interface LinePlotProps {
@@ -32,8 +31,8 @@ export interface LinePlotProps {
 }
 
 interface LineProps {
-  key: string,
-  name: string,
+  key: string
+  name: string
   color: string
   legendType?: RechartsLineProps['legendType']
 }
@@ -70,23 +69,35 @@ export function DeterministicLinePlot({ data, userResult, logScale, caseCounts }
   const nHospitalBeds = data.params.hospitalBeds
   const nICUBeds = data.params.ICUBeds
 
-  let observations = []
-  const count_observations = {cases:0, ICU:0, observedDeaths:0, newCases:0, hospitalized:0}
+  const observations = []
+  const count_observations = { cases: 0, ICU: 0, observedDeaths: 0, newCases: 0, hospitalized: 0 }
   if (caseCounts) {
-    caseCounts.sort(function(a,b){ return (a.time>b.time)?1:-1});
-    caseCounts.forEach(function(d, i) {
-      if (d.cases) {count_observations.cases += 1}
-      if (d.deaths) {count_observations.observedDeaths += 1}
-      if (d.hospitalized) {count_observations.hospitalized += 1}
-      if (d.ICU) {count_observations.ICU += 1}
-      if (i>2 && d.cases && caseCounts[i-3].cases) {count_observations.newCases += 1}
+    caseCounts.sort(function (a, b) {
+      return a.time > b.time ? 1 : -1
+    })
+    caseCounts.forEach(function (d, i) {
+      if (d.cases) {
+        count_observations.cases += 1
+      }
+      if (d.deaths) {
+        count_observations.observedDeaths += 1
+      }
+      if (d.hospitalized) {
+        count_observations.hospitalized += 1
+      }
+      if (d.ICU) {
+        count_observations.ICU += 1
+      }
+      if (i > 2 && d.cases && caseCounts[i - 3].cases) {
+        count_observations.newCases += 1
+      }
       observations.push({
-        time: (new Date(d.time)).getTime(),
+        time: new Date(d.time).getTime(),
         cases: d.cases || undefined,
         observedDeaths: d.deaths || undefined,
         currentHospitalized: d.hospitalized || undefined,
         ICU: d.ICU || undefined,
-        newCases: (i>2)?((d.cases - caseCounts[i-3].cases) || undefined):undefined,
+        newCases: i > 2 ? d.cases - caseCounts[i - 3].cases || undefined : undefined,
         hospitalBeds: nHospitalBeds,
         ICUbeds: nICUBeds,
       })
@@ -95,7 +106,7 @@ export function DeterministicLinePlot({ data, userResult, logScale, caseCounts }
 
   let plotData = data.deterministicTrajectory
     .filter((d, i) => i % 4 === 0)
-    .map(x => ({
+    .map((x) => ({
       time: x.time,
       susceptible: Math.round(x.susceptible.total) || undefined,
       exposed: Math.round(x.exposed.total) || undefined,
@@ -110,40 +121,40 @@ export function DeterministicLinePlot({ data, userResult, logScale, caseCounts }
     }))
   const scatterToPlot: LineProps[] = []
   const linesToPlot: LineProps[] = [
-      {key:'hospitalBeds', color: colors.hospitalBeds, name:t('Total hospital beds'), legendType:"none"},
-      {key:'ICUbeds', color: colors.ICUbeds, name:t('Total ICU/ICM beds'), legendType:"none"},
-      {key:'susceptible', color: colors.susceptible, name:t('Susceptible'), legendType:"line"},
-      //{key:'exposed', color: colors.exposed, name:'', legendType:"line"},
-      {key:'infectious', color: colors.infectious, name:t('Infectious'), legendType:"line"},
-      // {key:'hospitalized', color: colors.severe, name:'Severely ill', legendType:"line"},
-      {key:'critical', color: colors.critical, name:t('Patients in ICU'), legendType:"line"},
-      {key:'overflow', color: colors.overflow, name:t('ICU overflow'), legendType:"line"},
-      {key:'recovered', color: colors.recovered, name:t('Recovered'), legendType:"line"},
-      {key:'dead', color: colors.death, name:t('Cumulative deaths'), legendType:"line"},
+    { key: 'hospitalBeds', color: colors.hospitalBeds, name: t('Total hospital beds'), legendType: 'none' },
+    { key: 'ICUbeds', color: colors.ICUbeds, name: t('Total ICU/ICM beds'), legendType: 'none' },
+    { key: 'susceptible', color: colors.susceptible, name: t('Susceptible'), legendType: 'line' },
+    // {key:'exposed', color: colors.exposed, name:'', legendType:"line"},
+    { key: 'infectious', color: colors.infectious, name: t('Infectious'), legendType: 'line' },
+    // {key:'hospitalized', color: colors.severe, name:'Severely ill', legendType:"line"},
+    { key: 'critical', color: colors.critical, name: t('Patients in ICU'), legendType: 'line' },
+    { key: 'overflow', color: colors.overflow, name: t('ICU overflow'), legendType: 'line' },
+    { key: 'recovered', color: colors.recovered, name: t('Recovered'), legendType: 'line' },
+    { key: 'dead', color: colors.death, name: t('Cumulative deaths'), legendType: 'line' },
   ]
 
-  let tMin = plotData[0].time;
-  let tMax = plotData[plotData.length-1].time;
+  let tMin = plotData[0].time
+  let tMax = plotData[plotData.length - 1].time
   // Append empirical data
   if (observations.length) {
-      tMin = Math.min(tMin, observations[0].time);
-      tMax = Math.max(tMax, observations[observations.length-1].time);
-      plotData = plotData.concat(observations) //.filter((d) => {return d.time >= tMin && d.time <= tMax}))
-      if (count_observations.observedDeaths){
-        scatterToPlot.push({key:'observedDeaths', 'color': colors.death, name: t('Cumulative confirmed deaths')})
-      }
-      if (count_observations.cases){
-        scatterToPlot.push({key:'cases', 'color': colors.cumulativeCases, name: t('Cumulative confirmed cases')})
-      }
-      if (count_observations.hospitalized){
-        scatterToPlot.push({key:'currentHospitalized', 'color': colors.severe, name: t('Patients in hospital')})
-      }
-      if (count_observations.ICU){
-        scatterToPlot.push({key:'ICU', 'color': colors.critical, name: t('Patients in ICU')})
-      }
-      if (count_observations.newCases){
-        scatterToPlot.push({key:'newCases', 'color': colors.newCases, name: t('Confirmed cases past 3 days')})
-      }
+    tMin = Math.min(tMin, observations[0].time)
+    tMax = Math.max(tMax, observations[observations.length - 1].time)
+    plotData = plotData.concat(observations) // .filter((d) => {return d.time >= tMin && d.time <= tMax}))
+    if (count_observations.observedDeaths) {
+      scatterToPlot.push({ key: 'observedDeaths', color: colors.death, name: t('Cumulative confirmed deaths') })
+    }
+    if (count_observations.cases) {
+      scatterToPlot.push({ key: 'cases', color: colors.cumulativeCases, name: t('Cumulative confirmed cases') })
+    }
+    if (count_observations.hospitalized) {
+      scatterToPlot.push({ key: 'currentHospitalized', color: colors.severe, name: t('Patients in hospital') })
+    }
+    if (count_observations.ICU) {
+      scatterToPlot.push({ key: 'ICU', color: colors.critical, name: t('Patients in ICU') })
+    }
+    if (count_observations.newCases) {
+      scatterToPlot.push({ key: 'newCases', color: colors.newCases, name: t('Confirmed cases past 3 days') })
+    }
   }
   const logScaleString = logScale ? t('log') : t('linear')
 
@@ -172,39 +183,34 @@ export function DeterministicLinePlot({ data, userResult, logScale, caseCounts }
                 }}
               >
                 <CartesianGrid strokeDasharray="3 3" />
-                <XAxis dataKey="time" type="number" tickFormatter={xTickFormatter} domain={[tMin, tMax]} tickCount={7}/>
+                <XAxis
+                  dataKey="time"
+                  type="number"
+                  tickFormatter={xTickFormatter}
+                  domain={[tMin, tMax]}
+                  tickCount={7}
+                />
                 <YAxis scale={logScaleString} type="number" domain={[1, 'dataMax']} />
                 <Tooltip formatter={tooltipFormatter} labelFormatter={labelFormatter} />
                 <Legend verticalAlign="top" />
-                {
-                  linesToPlot.map(d => {
-                    return (
-                      <Line
-                        key={d.key}
-                        dot={false}
-                        isAnimationActive={false}
-                        type='monotone'
-                        strokeWidth={3}
-                        dataKey={d.key}
-                        stroke={d.color}
-                        name={d.name}
-                        legendType={d.legendType}
-                      />
-                    )
-                    })
-                }
-                {
-                  scatterToPlot.map(d => {
-                    return (
-                      <Scatter
-                        key={d.key}
-                        dataKey={d.key}
-                        fill={d.color}
-                        name={d.name}
-                      />
-                    )
-                    })
-                }
+                {linesToPlot.map((d) => {
+                  return (
+                    <Line
+                      key={d.key}
+                      dot={false}
+                      isAnimationActive={false}
+                      type="monotone"
+                      strokeWidth={3}
+                      dataKey={d.key}
+                      stroke={d.color}
+                      name={d.name}
+                      legendType={d.legendType}
+                    />
+                  )
+                })}
+                {scatterToPlot.map((d) => {
+                  return <Scatter key={d.key} dataKey={d.key} fill={d.color} name={d.name} />
+                })}
               </ComposedChart>
             </>
           )

--- a/src/components/Main/Results/DeterministicLinePlot.tsx
+++ b/src/components/Main/Results/DeterministicLinePlot.tsx
@@ -60,11 +60,12 @@ function labelFormatter(value: string | number): React.ReactNode {
 }
 
 export function DeterministicLinePlot({ data, userResult, logScale, caseCounts }: LinePlotProps) {
+  const { t } = useTranslation()
+
   // FIXME: is `data.stochasticTrajectories.length > 0` correct here?
   if (!data || data.stochasticTrajectories.length > 0) {
     return null
   }
-  const { t } = useTranslation()
   const hasUserResult = Boolean(userResult?.trajectory)
   const nHospitalBeds = data.params.hospitalBeds
   const nICUBeds = data.params.ICUBeds
@@ -190,7 +191,12 @@ export function DeterministicLinePlot({ data, userResult, logScale, caseCounts }
                   domain={[tMin, tMax]}
                   tickCount={7}
                 />
-                <YAxis scale={logScaleString} type="number" domain={[1, 'dataMax']} />
+                <YAxis
+                  scale={logScaleString}
+                  type="number"
+                  domain={[1, 'dataMax']}
+                  tickFormatter={(tick) => t('localized:number', { value: tick })}
+                />
                 <Tooltip formatter={tooltipFormatter} labelFormatter={labelFormatter} />
                 <Legend verticalAlign="top" />
                 {linesToPlot.map((d) => {

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -19,6 +19,12 @@ i18n
 
     interpolation: {
       escapeValue: false,
+      format(value, format, lng) {
+        if (format === 'localizedNumber') {
+          return new Intl.NumberFormat(lng).format(value)
+        }
+        return value
+      },
     },
 
     react: {

--- a/src/locales/en/index.ts
+++ b/src/locales/en/index.ts
@@ -1,3 +1,4 @@
 import * as translation from './translation.json'
+import * as localized from '../localized/localized.json'
 
-export default { translation }
+export default { localized, translation }

--- a/src/locales/localized/localized.json
+++ b/src/locales/localized/localized.json
@@ -1,0 +1,3 @@
+{
+  "number": "{{value, localizedNumber}}"
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -12046,10 +12046,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@1.19.1:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
-  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+prettier@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.1.tgz#3f00ac71263be34684b2b2c8d7e7f63737592dac"
+  integrity sha512-piXGBcY1zoFOG0MvHpNE5reAGseLmaCRifQ/fmfF49BcYkInEs/naD/unxGNAeOKFA5+JxVrPyMvMlpzcd20UA==
 
 pretty-bytes@5.3.0, pretty-bytes@^5.3.0:
   version "5.3.0"


### PR DESCRIPTION
## Description

- Add localizedNumber to languages
- Format DeterministicLinePlot according to project style guide
- Format labels on Y axis 

## Related issues

- Contributes to https://github.com/neherlab/covid19_scenarios/issues/101
- Contributes to https://github.com/neherlab/covid19_scenarios/issues/83
- Contributes to https://github.com/neherlab/covid19_scenarios/issues/56

## Impacted Areas in the application

It is also now possible to format any number according to the locale of the selected language, eg: `t('localized:number', { value: 1000 })`
This is applied to the numbers on the Y Axis of the graph

