### PR TITLE
Fix DeterministicLinePlot.tsx type errors and upgrade Prettier to 2.0.1

### DIFF
--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -92,13 +92,14 @@ function Main() {
     // TODO: check the presence of the current counry
     // TODO: type cast the json into something
     const ageDistribution = countryAgeDistribution[params.population.country]
-    const caseCounts      = countryCaseCounts[scenarioState.population.data.cases] || []
+    const caseCounts: typeof empiricalCases = countryCaseCounts[scenarioState.population.data.cases] || []
     const containmentData = scenarioState.containment.data.reduction
 
     serializeScenarioToURL(scenarioState, params)
     const newResult = await run(paramsFlat, severity, ageDistribution, containmentData)
 
     setResult(newResult)
+    caseCounts?.sort((a, b) => (a.time > b.time ? 1 : -1))
     setEmpiricalCases(caseCounts)
     setSubmitting(false)
   }

--- a/src/components/Main/Results/DeterministicLinePlot.tsx
+++ b/src/components/Main/Results/DeterministicLinePlot.tsx
@@ -70,8 +70,6 @@ export function DeterministicLinePlot({ data, userResult, logScale, caseCounts }
   const nHospitalBeds = data.params.hospitalBeds
   const nICUBeds = data.params.ICUBeds
 
-  caseCounts?.sort((a, b) => (a.time > b.time ? 1 : -1))
-
   const count_observations = {
     cases: caseCounts?.filter((d) => d.cases).length ?? 0,
     ICU: caseCounts?.filter((d) => d.ICU).length ?? 0,


### PR DESCRIPTION
## Description

- Fix the various type errors in `src/components/Main/Results/DeterministicLinePlot.tsx` by making the variables' types statically inferrable (accomplished with immutability). The logic is still the same though!
- [Type-only `import`s](https://github.com/neherlab/covid19_scenarios/blob/master/src/components/Main/Results/DeterministicLinePlot.tsx#L4) weren't [introduced to TypeScript until 3.8](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export), so I had to [upgrade Prettier to 2.0.1](https://prettier.io/blog/2020/03/21/2.0.0.html#typescript-38-7631httpsgithubcomprettierprettierpull7631-by-thorn0httpsgithubcomthorn0-7764httpsgithubcomprettierprettierpull7764-by-sosukesuzukihttpsgithubcomsosukesuzuki-7804httpsgithubcomprettierprettierpull7804-by-sosukesuzukihttpsgithubcomsosukesuzuki)
-
  ```bash
  npx prettier --write .src/components/Main/Results/DeterministicLinePlot.tsx
  ```
- move the `caseCounts.sort` from `DeterministicLinePlot.tsx` to `Main.tsx` (right before we "commit" `caseCounts` with `setEmpiricalCases` so that the browser isn't performing the sorting at every `render` in `DeterministicLinePlot.tsx`. This should help a lot with performance

## Related issues

https://github.com/neherlab/covid19_scenarios/issues/101

