### PR TITLE
fix AgeBarChart type errors

### DIFF
--- a/src/components/Main/Results/AgeBarChart.tsx
+++ b/src/components/Main/Results/AgeBarChart.tsx
@@ -24,7 +24,16 @@ export function AgeBarChart({ data, rates }: SimProps) {
     return null
   }
 
-  const { t } = useTranslation()
+  const { t: unsafeT } = useTranslation()
+  const t = (...args: Parameters<typeof unsafeT>) => {
+    const translation = unsafeT(...args)
+    if (typeof translation === 'string' || typeof translation === 'undefined') {
+      return translation
+    }
+
+    (process.env.NODE_ENV !== 'production') && console.warn('Translation incomatible in AgeBarChart.tsx', ...args)
+    return String(translation)
+  }
   const ages = Object.keys(data.params.ageDistribution)
   const lastDataPoint = data.deterministicTrajectory[data.deterministicTrajectory.length - 1]
   const plotData = ages.map(age => ({


### PR DESCRIPTION
## Description

`react-i18next`'s translation function (`useTranslation().t`) returns `TFunctionResult` (i.e. `string | object | Array<string | object> | undefined | null`), but `rechart`'s components only accept `string | number | undefined` for their `name`s, `label`s, .etc, so extend `TFunction` with a signature that returns _just_ `string | number | undefined`

## Related issues

https://github.com/neherlab/covid19_scenarios/issues/101
