### PR TITLE
redo FormHelpButton trigger

### DIFF
--- a/src/components/Form/FormHelpButton.tsx
+++ b/src/components/Form/FormHelpButton.tsx
@@ -1,10 +1,11 @@
-import React, { useState } from 'react'
+import React, { useState, useRef } from 'react'
 
 import { Button, Card, CardBody, CardHeader, Popover } from 'reactstrap'
 
 import { FaQuestion } from 'react-icons/fa'
 
 import './FormHelpButton.scss'
+import { useOuterClickNotifier } from '../../helpers/hooks'
 
 function safeId(id: string) {
   return id.replace('.', '-')
@@ -18,19 +19,18 @@ export interface FormHelpButtonProps {
 
 export default function FormHelpButton({ identifier, label, help }: FormHelpButtonProps) {
   const [popoverOpen, setPopoverOpen] = useState(false)
+  const buttonRef = useRef<HTMLButtonElement>();
+
+  useOuterClickNotifier(e => setPopoverOpen(false), buttonRef);
 
   return (
     <>
       <Button
+        ref={buttonRef}
         id={safeId(identifier)}
         className="help-button"
         type="button"
-        onClick={e => {
-          e.preventDefault()
-          e.stopPropagation()
-        }}
-        onFocus={() => setPopoverOpen(true)}
-        onBlur={() => setPopoverOpen(false)}
+        onClick={e => setPopoverOpen(!popoverOpen)}
         aria-label="help"
       >
         <FaQuestion className="help-button-icon" />

--- a/src/helpers/hooks.ts
+++ b/src/helpers/hooks.ts
@@ -1,13 +1,13 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, MutableRefObject } from 'react'
 
 /** @see {@tutorial https://stackoverflow.com/questions/53446020/how-to-compare-oldvalues-and-newvalues-on-react-hooks-useeffect} */
 export const usePrevious = <T>(value: T) => {
-  const ref = useRef<T>();
+  const ref = useRef<T>()
   useEffect(() => {
-    ref.current = value;
-  });
-  return ref.current;
-};
+    ref.current = value
+  })
+  return ref.current
+}
 
 export const useScrollIntoView = <T extends HTMLElement = any>(trigger: any) => {
   const refOfElementToScrollIntoView = useRef<T>(null)
@@ -19,14 +19,42 @@ export const useScrollIntoView = <T extends HTMLElement = any>(trigger: any) => 
   const previousTrigger = usePrevious(trigger)
 
   useEffect(() => {
-    trigger && !previousTrigger && setTimeout(() => {
-      /**
-       * scroll the viewport down to the point where the top of this element is at the top of the viewport
-       * @see {@tutorial https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView}
-       */
-      refOfElementToScrollIntoView.current?.scrollIntoView({ behavior: 'smooth', block: 'start', inline: 'nearest' })
-    })
+    trigger &&
+      !previousTrigger &&
+      setTimeout(() => {
+        /**
+         * scroll the viewport down to the point where the top of this element is at the top of the viewport
+         * @see {@tutorial https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView}
+         */
+        refOfElementToScrollIntoView.current?.scrollIntoView({ behavior: 'smooth', block: 'start', inline: 'nearest' })
+      })
   }, [trigger])
 
   return refOfElementToScrollIntoView
+}
+
+type ClickEvent = GlobalEventHandlers['onclick']
+
+/**
+ * @see {@tutorial https://stackoverflow.com/a/54292872/3942699}
+ * Custom outside click Hook
+ */
+export const useOuterClickNotifier = <T extends HTMLElement | undefined | null>(
+  onOuterClick: (e: ClickEvent) => any,
+  innerRef: MutableRefObject<T>,
+) => {
+  useEffect(
+    () => {
+      if (innerRef.current) {
+        // add listener only, if element exists
+        const handleClick: ClickEvent = (e) =>
+          innerRef.current && !innerRef.current?.contains?.(e.target as HTMLElement) && onOuterClick(e)
+
+        document.addEventListener('click', handleClick)
+        // unmount previous listener first
+        return () => document.removeEventListener('click', handleClick)
+      }
+    },
+    [onOuterClick, innerRef], // invoke again, if deps have changed
+  )
 }


### PR DESCRIPTION
## Description

Due to https://github.com/reactstrap/reactstrap/issues/1428 I had to replace the dependency on `onFocus` with a handler that would display the tooltip when the button is clicked, and then hide it when the user clicks outside of the tooltip

(This PR also performs `prettier --write` on `src/helpers/hooks.ts`)

## Related issues

https://github.com/neherlab/covid19_scenarios/issues/134