### PR TITLE
I134 fix for safari help

### DIFF
--- a/src/components/Form/FormHelpButton.tsx
+++ b/src/components/Form/FormHelpButton.tsx
@@ -26,6 +26,9 @@ export default function FormHelpButton({ identifier, label, help }: FormHelpButt
         className="help-button"
         type="button"
         onClick={e => {
+          if (!popoverOpen) {
+            e.currentTarget.focus()
+          }
           e.preventDefault()
           e.stopPropagation()
         }}


### PR DESCRIPTION
## Description

I believe this fixes #134. 

It seems there is no support for focus on button in safari:
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus

