### PR TITLE
issue #134: use an UncontrolledPopover to fix popovers for Safari

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -16,15 +16,24 @@ Please test using the latest version of the application to make sure the issue h
 
 <!--- Provide a general summary of the issue here -->
 
-## 🤔 Expected Behavior
+## How to reproduce
 
-<!--- Tell us what should happen -->
+Steps to reproduce the issue:
+
+ 1. Open the application in a browser
+
+ 2.
+
+ 3.
 
 ## 😯 Current Behavior
 
-<!--- Tell us what happens instead of the expected behavior -->
-
+<!--- Tell us what happens currently -->
 <!--- If you are seeing an error, please include the full error message and stack trace -->
+
+## 🤔 Expected Behavior
+
+<!--- Tell us what should happen -->
 
 ## 💁 Possible Solution
 
@@ -33,7 +42,6 @@ Please test using the latest version of the application to make sure the issue h
 ## 🔦 Context
 
 <!--- How has this issue affected you? What are you trying to accomplish? -->
-
 <!--- Providing context helps us come up with a solution that is most useful in the real world -->
 
 ## 💻 Code Sample
@@ -48,4 +56,4 @@ Please test using the latest version of the application to make sure the issue h
 | ---------------- | ---------- |
 | Browser          |
 | Operating System |
-| NPM/Node/Yarn    |
+|                  |

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,11 +1,11 @@
 ---
 name: 📚 Documentation
-about: Find an inaccuracy in the documentation or something missing?
+about: Found an inaccuracy in the documentation or something missing?
 labels: 'scope:documentation'
 ---
 
 <!---
-Thanks for filing an issue 😄! Before you submit, please read the following:
+Thanks for filing an issue😄! Before you submit, please read the following:
 
 Search open/closed issues before submitting since someone might have asked the same thing before!
 -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -13,26 +13,22 @@ Please provide a clear and concise description of what the feature would be.
 
 # 🙋 Feature Request
 
-<!--- Provide a general summary of the issue here -->
-
-## 🤔 Expected Behavior
-
-<!--- Tell us how the feature should work -->
-
-## 😯 Current Behavior
-
-<!--- Explain the difference from current behavior -->
-
-## 💁 Possible Solution
-
-<!--- Ideas how to implement this feature or a similar solution/workaround that already exists -->
+<!--- Provide a general summary of the new addition -->
 
 ## 🔦 Context
 
-<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- What are you trying to accomplish? How this new feature will help you? -->
 
 <!--- Providing context helps us come up with a solution that is most useful in the real world -->
+
+## 😯 Describe the feature
+
+<!--- Tell us how the feature should work in your opinion -->
 
 ## 💻 Examples
 
 <!-- Examples help us understand the requested feature better -->
+
+## 💁 Possible Solution
+
+<!--- Ideas how to implement this feature or a similar solution/workaround that already exists -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,31 +1,19 @@
 ## Description
 
-<!--
-  A few sentences describing the overall goals of the pull request's commits.
--->
+<!-- Goal of the pull request -->
 
 ## Related issues
 
 <!--
-  List related issues:
-    - Fixes https://github.com/neherlab/covid19_scenarios/issues/xy
-    - Contributes to https://github.com/neherlab/covid19_scenarios/issues/yz
+ - Fixes https://github.com/neherlab/covid19_scenarios/issues/xy
+ - Contributes to https://github.com/neherlab/covid19_scenarios/issues/yz
+ - Related to https://github.com/neherlab/covid19_scenarios/issues/yz
 -->
 
 ## Impacted Areas in the application
 
-<!--
-  List general components or areas of the application that this PR will affect.
--->
+<!-- Components of the application that this PR will change -->
 
 ## Testing
 
-<!--
-  Outline the steps to test the changes proposed by this PR.
--->
-
-## Deploy Notes
-
-<!--
-  Notes regarding specific deployment requirements for this PR, such as DB updates, migrations, etc.
--->
+<!-- Steps to test the changes proposed by this PR -->

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,10 @@ branches:
 
 language: node_js
 
-cache:
-  yarn: true
-  directories:
-    - node_modules
+cache: false
+#  yarn: true
+#  directories:
+#    - node_modules
 
 install:
   - yarn install --frozen-lockfile

--- a/src/components/Form/FormHelpButton.test.tsx
+++ b/src/components/Form/FormHelpButton.test.tsx
@@ -51,14 +51,14 @@ describe('FormHelpButton', () => {
     const { getByLabelText, findByText, getByText, queryByText } = render(
       <div>
         <FormHelpButton identifier="abc" label="def" />
-        <span>click here</span>
+        <span>click outside</span>
       </div>,
     )
     fireEvent.click(getByLabelText('help'))
     await findByText('def')
     expect(queryByText('def')).not.toBeNull()
 
-    fireEvent.click(getByText('click here'))
+    fireEvent.click(getByText('click outside'))
 
     await waitForElementToBeRemoved(() => queryByText('def'))
     expect(queryByText('def')).toBeNull()

--- a/src/components/Form/FormHelpButton.test.tsx
+++ b/src/components/Form/FormHelpButton.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, fireEvent } from '@testing-library/react'
+import { render, fireEvent, waitForElementToBeRemoved } from '@testing-library/react'
 import FormHelpButton from './FormHelpButton'
 
 describe('FormHelpButton', () => {
@@ -15,28 +15,52 @@ describe('FormHelpButton', () => {
     expect(queryByText('def')).toBeNull()
   })
 
-  it('opens', () => {
-    const { getByLabelText, queryByText } = render(<FormHelpButton identifier="abc" label="def" />)
+  it('opens', async () => {
+    const { getByLabelText, findByText, queryByText } = render(<FormHelpButton identifier="abc" label="def" />)
 
-    fireEvent.focus(getByLabelText('help'))
+    fireEvent.click(getByLabelText('help'))
 
+    await findByText('def')
     expect(queryByText('def')).not.toBeNull()
   })
 
-  it('displays help', () => {
-    const { getByLabelText, getByText } = render(<FormHelpButton identifier="abc" label="def" help="some help" />)
+  it('displays help', async () => {
+    const { getByLabelText, findByText, queryByText } = render(
+      <FormHelpButton identifier="abc" label="def" help="some help" />,
+    )
 
-    fireEvent.focus(getByLabelText('help'))
+    fireEvent.click(getByLabelText('help'))
 
-    expect(getByText('some help')).toBeTruthy()
+    await findByText('some help')
+    expect(queryByText('some help')).toBeTruthy()
   })
 
-  it('closes', () => {
-    const { getByLabelText, queryByText } = render(<FormHelpButton identifier="abc" label="def" />)
+  it('closes inside', async () => {
+    const { getByLabelText, findByText, queryByText } = render(<FormHelpButton identifier="abc" label="def" />)
+    fireEvent.click(getByLabelText('help'))
+    await findByText('def')
+    expect(queryByText('def')).not.toBeNull()
 
-    fireEvent.focus(getByLabelText('help'))
-    fireEvent.blur(getByLabelText('help'))
+    fireEvent.click(getByLabelText('help'))
 
+    await waitForElementToBeRemoved(() => queryByText('def'))
+    expect(queryByText('def')).toBeNull()
+  })
+
+  it('closes outside', async () => {
+    const { getByLabelText, findByText, getByText, queryByText } = render(
+      <div>
+        <FormHelpButton identifier="abc" label="def" />
+        <span>click here</span>
+      </div>,
+    )
+    fireEvent.click(getByLabelText('help'))
+    await findByText('def')
+    expect(queryByText('def')).not.toBeNull()
+
+    fireEvent.click(getByText('click here'))
+
+    await waitForElementToBeRemoved(() => queryByText('def'))
     expect(queryByText('def')).toBeNull()
   })
 })

--- a/src/components/Form/FormHelpButton.tsx
+++ b/src/components/Form/FormHelpButton.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from 'react'
+import React from 'react'
 
-import { Button, Card, CardBody, CardHeader, Popover } from 'reactstrap'
+import { Button, Card, CardBody, CardHeader, UncontrolledPopover } from 'reactstrap'
 
 import { FaQuestion } from 'react-icons/fa'
 
@@ -17,14 +17,13 @@ export interface FormHelpButtonProps {
 }
 
 export default function FormHelpButton({ identifier, label, help }: FormHelpButtonProps) {
-  const [popoverOpen, setPopoverOpen] = useState(false)
-
   return (
     <>
       <Button
         id={safeId(identifier)}
         className="help-button"
         type="button"
+        aria-label="help"
         onClick={e => {
           if (!popoverOpen) {
             e.currentTarget.focus()
@@ -32,18 +31,15 @@ export default function FormHelpButton({ identifier, label, help }: FormHelpButt
           e.preventDefault()
           e.stopPropagation()
         }}
-        onFocus={() => setPopoverOpen(true)}
-        onBlur={() => setPopoverOpen(false)}
-        aria-label="help"
       >
         <FaQuestion className="help-button-icon" />
       </Button>
-      <Popover placement="right" target={safeId(identifier)} trigger="focus" hideArrow isOpen={popoverOpen}>
+      <UncontrolledPopover placement="right" target={safeId(identifier)} trigger="legacy" hideArrow>
         <Card>
           <CardHeader>{label}</CardHeader>
           <CardBody>{help}</CardBody>
         </Card>
-      </Popover>
+      </UncontrolledPopover>
     </>
   )
 }


### PR DESCRIPTION
## Description

Help information would not display for Safari users.

## Related issues

Fixes https://github.com/neherlab/covid19_scenarios/issues/134

## Impacted Areas in the application

Help Popovers.

## Testing

- Tested with Chrome & Safari on MacOS
- Changed the help popover unit test to use clicks

## Deploy Notes

None