### PR TITLE
Make chart lines/scatters toggleable

### DIFF
--- a/src/components/Main/Results/DeterministicLinePlot.scss
+++ b/src/components/Main/Results/DeterministicLinePlot.scss
@@ -1,0 +1,9 @@
+.legend {
+    cursor: pointer;
+}
+
+.legend-inactive {
+    @extend .legend;
+    color: #A9A9A9;
+    text-decoration: line-through;
+}


### PR DESCRIPTION
Add the ability to toggle visibility of chart elements by clicking the legend.

Legend elements now show with hand cursor to indicate interactivity.  Clicking will toggle visibility of line/scatter, and legend text will show with dark-grey color and strikethrough when disabled.

## Description

Add the ability to toggle rendering of lines/scatters on the result chart.

![Snip of graph with data disabled](https://user-images.githubusercontent.com/2041260/77282145-570b5780-6c86-11ea-9c09-3d2496d57400.png)


## Related issues

 - Fixes https://github.com/neherlab/covid19_scenarios/issues/132

## Impacted Areas in the application

DeterministicLinePlot.tsx

## Testing

Pull branch, run simulation, observe hand cursor over legend labels, clicking legend label toggles visibility of the chart data, and legend label shows with dark-grey color and strike-through when disabled.
