### PR TITLE
Add disclaimer to the home page

### DIFF
--- a/src/components/Main/Disclaimer.tsx
+++ b/src/components/Main/Disclaimer.tsx
@@ -49,9 +49,9 @@ export default function DisclaimerProps() {
           DEALINGS IN THE SOFTWARE.
           <br />
           <br />
-          This tool uses theoretical mathematics to model a variety of COVID-19 outcomes based on user defined
-          parameters. This tool is not a medical predictor, and should be used for informative and research purposes
-          only; please use the simulated results responsibly.
+          This tool uses a mathematical model to simulate a variety of COVID-19 outcomes based on user-defined parameters.
+          This tool is not a medical predictor, and should be used for informative and research purposes only;
+          please use the simulated results responsibly.
           <br />
           <br />
           <strong>GDPR disclaimer:</strong> This tool writes small amounts of data to your device's local storage to

--- a/src/components/Main/Disclaimer.tsx
+++ b/src/components/Main/Disclaimer.tsx
@@ -1,0 +1,80 @@
+import React, { useEffect, useState } from 'react'
+import { Modal, ModalHeader, ModalBody, ModalFooter, Button } from 'reactstrap'
+
+const disclaimerVersion = 0
+const SUPPRESS_DISCLAIMER_ID = 'suppress-disclaimer'
+
+interface SuppressShowAgain {
+  version: number
+  suppressShowAgain: boolean
+}
+
+function onDialogClosed(suppressShowAgain: boolean) {
+  const persist: SuppressShowAgain = {
+    version: disclaimerVersion,
+    suppressShowAgain,
+  }
+
+  localStorage.setItem(SUPPRESS_DISCLAIMER_ID, JSON.stringify(persist))
+}
+
+export default function DisclaimerProps() {
+  const [showModal, setShowModal] = useState(false)
+  const [suppressShowAgain, setsuppressShowAgain] = useState(false)
+
+  useEffect(() => {
+    const localStorageItem = localStorage.getItem(SUPPRESS_DISCLAIMER_ID)
+
+    if (localStorageItem) {
+      const suppressItem: SuppressShowAgain = JSON.parse(localStorageItem)
+      setsuppressShowAgain(suppressItem.suppressShowAgain)
+      setShowModal(!suppressItem.suppressShowAgain || suppressItem.version < disclaimerVersion)
+    } else {
+      setShowModal(true)
+    }
+  }, [])
+
+  const toggle = () => setShowModal(!showModal)
+  const toggleChecked = () => setsuppressShowAgain(!suppressShowAgain)
+
+  return (
+    <Modal isOpen={showModal} centered toggle={toggle} onClosed={() => onDialogClosed(suppressShowAgain)}>
+      <ModalHeader toggle={toggle}>COVID-19 Scenario Disclaimer</ModalHeader>
+      <ModalBody>
+        <div className="row mx-md-3">
+          THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+          TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+          AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+          CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+          DEALINGS IN THE SOFTWARE.
+          <br />
+          <br />
+          This tool uses theoretical mathematics to model a variety of COVID-19 outcomes based on user defined
+          parameters. This tool is not a medical predictor, and should be used for informative and research purposes
+          only; please use the simulated results responsibly.
+          <br />
+          <br />
+          <strong>GDPR disclaimer:</strong> This tool writes small amounts of data to your device's local storage to
+          improve the user experience. Your continued use of the tool constitutes acceptance.
+        </div>
+        <div className="row float-right mt-sm-3 pr-md-3">
+          <label className="form-check-label">
+            <input
+              type="checkbox"
+              className="form-check-input"
+              onChange={toggleChecked}
+              checked={suppressShowAgain}
+              ariaChecked={suppressShowAgain}
+            />
+            Don't show again
+          </label>
+        </div>
+      </ModalBody>
+      <ModalFooter>
+          <Button color="primary" onClick={toggle}>
+            Accept
+          </Button>
+      </ModalFooter>
+    </Modal>
+  )
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,15 +1,15 @@
 import React from 'react'
 
 import Main from '../components/Main/Main'
+import Disclaimer from '../components/Main/Disclaimer'
 
 import './Home.scss'
 
 function Home() {
   return (
     <>
-      <div>
-        <Main />
-      </div>
+      <Main />
+      <Disclaimer />
     </>
   )
 }


### PR DESCRIPTION
### Description

Add disclaimer modal dialog which shows by default.

Disclaimer contains basic MIT software disclaimer, plus responsible use request, and GDPR local storage disclosure.

Disclaimer has "don't show me again" checkbox, which will suppress future showing on the same device, unless the disclaimer version number is increased.

![Screenshot of functionality](https://user-images.githubusercontent.com/2041260/77290727-0140aa80-6c9a-11ea-91f3-09ce6b592da5.png)

## Related issues

 - Fixes https://github.com/neherlab/covid19_scenarios/issues/25

## Impacted Areas in the application

Disclaimer which will show on mount of main simulation page, '/'

## Testing

Pull branch, observe that dialog shows on mount of simulation main page with disclaimer content.  Disclaimer will show on all subsequent loads of the page, unless 'Don't ask me again' was checked when the disclaimer was dismissed, in which case, it won't show again unless localstorage is cleared, or disclaimer version is bumped.
