### PR TITLE
fix key for death count in plot set-up

### DIFF
--- a/src/components/Main/Results/DeterministicLinePlot.tsx
+++ b/src/components/Main/Results/DeterministicLinePlot.tsx
@@ -85,7 +85,7 @@ function labelFormatter(value: string | number): React.ReactNode {
 }
 
 function legendFormatter(enabledPlots: string[], value: string, entry: any)
-{ 
+{
   const activeClassName = enabledPlots.indexOf(entry.dataKey) !== -1 ? "legend" : "legend-inactive";
   return <span className={activeClassName}>{value}</span>;
 }
@@ -136,7 +136,7 @@ export function DeterministicLinePlot({ data, userResult, logScale, caseCounts }
         critical: enabledPlots.indexOf(DATA_POINTS.Critical) !== -1 ? Math.round(x.critical.total) || undefined : undefined,
         overflow: enabledPlots.indexOf(DATA_POINTS.Overflow) !== -1 ? Math.round(x.overflow.total) || undefined : undefined,
         recovered: enabledPlots.indexOf(DATA_POINTS.Recovered) !== -1 ? Math.round(x.recovered.total) || undefined : undefined,
-        dead: enabledPlots.indexOf(DATA_POINTS.Death) !== -1 ? Math.round(x.dead.total) || undefined : undefined,
+        death: enabledPlots.indexOf(DATA_POINTS.Death) !== -1 ? Math.round(x.dead.total) || undefined : undefined,
         hospitalBeds: nHospitalBeds,
         ICUbeds: nICUBeds,
       })),
@@ -222,7 +222,7 @@ export function DeterministicLinePlot({ data, userResult, logScale, caseCounts }
                 />
                 <Tooltip formatter={tooltipFormatter} labelFormatter={labelFormatter} />
                 <Legend
-                  verticalAlign="top" 
+                  verticalAlign="top"
                   formatter={(v, e) => legendFormatter(enabledPlots, v, e)}
                   onClick={e => {
                     const plots = enabledPlots.slice(0);


### PR DESCRIPTION
## Description
fix problem with wrong key in plot-data set up. That said, or nomenclature regarding `dead` `death` and `deaths` is for from ideal. 

## Impacted Areas in the application
Only affects the data aggregation for the plot. 
