### PR TITLE
#101/Fix type conflict caused by global exports of Chai, a Cypress dependency.

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,6 +26,26 @@
     "sourceMap": true,
     "strict": true
   },
-  "exclude": [".build", ".cache", ".ignore", ".reports", "3rdparty", "node_modules", "static", "tsconfig.json"],
-  "include": ["./.js", "./.jsx", "./.ts", "./.tsx", "./**/*.js", "./**/*.json", "./**/*.jsx", "./**/*.ts", "./**/*.tsx"]
+  "include": [
+    "./.js",
+    "./.jsx",
+    "./.ts",
+    "./.tsx",
+    "./**/*.js",
+    "./**/*.json",
+    "./**/*.jsx",
+    "./**/*.ts",
+    "./**/*.tsx"
+  ],
+  "exclude": [
+    ".build",
+    ".cache",
+    ".ignore",
+    ".reports",
+    "3rdparty",
+    "node_modules",
+    "static",
+    "tsconfig.json",
+    "cypress"
+  ]
 }


### PR DESCRIPTION
## Description

This fix addresses a specific class of type errors in the unit tests. Both Jest and Chai (a Cypress dependency) declare a global "Assertion" type. Under certain conditions the Chai version takes precedence, resulting in the type error. For example: 

`error TS2339: Property 'toBeObject' does not exist on type 'Assertion'.`

This fix works by excluding the cypress/ folder from `tsconfig.json`, thereby keeping the unnecessary Chai definitions out of the global namespace.

## Related issues

#101 

## Impacted Areas in the application

Unit tests.

## Testing

`yarn test:lint`
