### PR TITLE
#101/Use existing CountryAgeDistribution type in unit test.

### DIFF
--- a/src/algorithms/test/run.test.tsx
+++ b/src/algorithms/test/run.test.tsx
@@ -1,6 +1,7 @@
 import { AllParamsFlat } from '../types/Param.types'
 import { AlgorithmResult } from '../types/Result.types'
 
+import { CountryAgeDistribution } from '../../assets/data/CountryAgeDistribution.types'
 import countryAgeDistribution from '../../assets/data/country_age_distribution.json'
 import severityData from '../../assets/data/severityData.json'
 import populationScenarios from '../../assets/data/scenarios/populations'
@@ -75,8 +76,9 @@ describe('run()', () => {
       'United States',
     ]
 
+    const countryAgeDistributionWithType = countryAgeDistribution as CountryAgeDistribution
+
     const results: Array<Promise<AlgorithmResult>> = countries.map((country) => {
-      const countryAgeDistributionWithType = countryAgeDistribution as Record<string, any>
       const populationScenario = populationScenarios.find((p) => p.name === country)
 
       // Confirm that the populationScenario is defined, because


### PR DESCRIPTION

## Description

This fixes a type warning in the `run.test.tsx` unit test:
_"Unexpected any. Specify a different type"_.

The fix is trivial, because the  appropriate type is already defined in:
`src/assets/CountryAgeDistribution.types.ts`

## Related issues

#101 

## Impacted Areas in the application

Unit tests.

## Testing

`yarn test:lint`
