### PR TITLE
performance: only render results if they shallowly change

### DIFF
--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -35,11 +35,11 @@ import './Main.scss'
 import { useScrollIntoView } from '../../helpers/hooks'
 
 export function severityTableIsValid(severity: SeverityTableRow[]) {
-  return !severity.some(row => _.values(row?.errors).some(x => x !== undefined))
+  return !severity.some((row) => _.values(row?.errors).some((x) => x !== undefined))
 }
 
 export function severityErrors(severity: SeverityTableRow[]) {
-  return severity.map(row => row?.errors)
+  return severity.map((row) => row?.errors)
 }
 
 const severityDefaults: SeverityTableRow[] = updateSeverityTable(severityData)
@@ -123,10 +123,10 @@ function Main() {
             /**
              * 992 is the width at which the layout collapses into a single column
              * @see {@tutorial https://getbootstrap.com/docs/4.0/layout/overview/#responsive-breakpoints}
-             * 
+             *
              * only `scrollIntoView` when `isSubmitting` goes from `true` -> `false`
              */
-            const refOfElementToScrollIntoView = useScrollIntoView<HTMLDivElement>(!isSubmitting && (vw < 992))
+            const refOfElementToScrollIntoView = useScrollIntoView<HTMLDivElement>(!isSubmitting && vw < 992)
 
             const canRun = isValid && severityTableIsValid(severity)
 
@@ -146,7 +146,7 @@ function Main() {
 
                   <Col lg={8} xl={6} className="py-1 px-1">
                     <div ref={refOfElementToScrollIntoView}>
-                      <ResultsCard canRun={canRun} severity={severity} result={result} caseCounts={empiricalCases}/>
+                      <ResultsCard canRun={canRun} severity={severity} result={result} caseCounts={empiricalCases} />
                     </div>
                   </Col>
                 </Row>

--- a/src/components/Main/Results/ResultsCard.tsx
+++ b/src/components/Main/Results/ResultsCard.tsx
@@ -9,7 +9,7 @@ import { exportResult } from '../../../algorithms/utils/exportResult'
 import { AlgorithmResult, UserResult } from '../../../algorithms/types/Result.types'
 import processUserResult from '../../../algorithms/utils/userResult'
 
-import { EmpiricalData }from '../../../algorithms/types/Param.types'
+import { EmpiricalData } from '../../../algorithms/types/Param.types'
 
 import { CollapsibleCard } from '../../Form/CollapsibleCard'
 import FormSwitch from '../../Form/FormSwitch'
@@ -25,14 +25,14 @@ import { OutcomeRatesTable } from './OutcomeRatesTable'
 
 import { useTranslation } from 'react-i18next'
 
-export interface ResutsCardProps {
+interface ResultsCardProps {
   canRun: boolean
   severity: SeverityTableRow[] // TODO: pass severity throughout the algorithm and as a part of `AlgorithmResult` instead?
   result?: AlgorithmResult
   caseCounts?: EmpiricalData
 }
 
-function ResultsCard({ canRun, severity, result, caseCounts }: ResutsCardProps) {
+function ResultsCardFunction({ canRun, severity, result, caseCounts }: ResultsCardProps) {
   const { t } = useTranslation()
   const [logScale, setLogScale] = useState<boolean>(true)
 
@@ -71,7 +71,9 @@ function ResultsCard({ canRun, severity, result, caseCounts }: ResutsCardProps) 
       <Row noGutters>
         <Col>
           <p>
-            {t('This output of a mathematical model depends on model assumptions and parameter choices. We have done our best (in limited time) to check the model implementation is correct. Please carefully consider the parameters you choose and interpret the output with caution')}
+            {t(
+              'This output of a mathematical model depends on model assumptions and parameter choices. We have done our best (in limited time) to check the model implementation is correct. Please carefully consider the parameters you choose and interpret the output with caution',
+            )}
           </p>
         </Col>
       </Row>
@@ -79,13 +81,7 @@ function ResultsCard({ canRun, severity, result, caseCounts }: ResutsCardProps) 
         <Col>
           <div>
             <span>
-              <Button
-                className="run-button"
-                type="submit"
-                color="primary"
-                disabled={!canRun}
-                data-testid="RunResults"
-              >
+              <Button className="run-button" type="submit" color="primary" disabled={!canRun} data-testid="RunResults">
                 {t('Run')}
               </Button>
             </span>
@@ -137,4 +133,4 @@ function ResultsCard({ canRun, severity, result, caseCounts }: ResutsCardProps) 
   )
 }
 
-export { ResultsCard }
+export const ResultsCard = React.memo(ResultsCardFunction)


### PR DESCRIPTION
## Description

When the scenario form is interacted with the entire wrapped <Formik> is re-rendered. There is a sluggishness that is especially noticeable when the run results are displayed. This change causes the ResultsCard to only re-render when a prop shallowly changes via React.memo. 

Note: The only change in this diff that matters is the `React.memo` export. The rest are auto-save prettier lint fixes.

## Related issues

Related to https://github.com/neherlab/covid19_scenarios/issues/17

## Impacted Areas in the application

Form performance.

## Testing

Run. Then interact with the form. It should be reasonably performant.