### PR TITLE
test: Fix regression failure in algorithms/test/run.test.tsx

### DIFF
--- a/src/algorithms/test/run.test.tsx
+++ b/src/algorithms/test/run.test.tsx
@@ -42,48 +42,10 @@ describe('run()', () => {
   })
 
   it('should work for a lot of countries', async () => {
-    const countries = [
-      'Switzerland',
-      'Germany',
-      'France',
-      'Italy',
-      'Spain',
-      'Poland',
-      'Romania',
-      'Netherlands',
-      'Belgium',
-      'Czechia',
-      'Greece',
-      'Portugal',
-      'Sweden',
-      'Hungary',
-      'Austria',
-      'Bulgaria',
-      'Denmark',
-      'Finland',
-      'Slovakia',
-      'Ireland',
-      'Croatia',
-      'Lithuania',
-      'Slovenia',
-      'Latvia',
-      'Estonia',
-      'Cyprus',
-      'Luxembourg',
-      'Malta',
-      'Canada',
-      'United Kingdom',
-      'United States',
-    ]
 
     const countryAgeDistributionWithType = countryAgeDistribution as CountryAgeDistribution
 
-    const results: Array<Promise<AlgorithmResult>> = countries.map((country) => {
-      const populationScenario = populationScenarios.find((p) => p.name === country)
-
-      // Confirm that the populationScenario is defined, because
-      // then we can safely apply the "! - Non-null assertion operator"
-      expect(populationScenario).toBeDefined()
+    const results: Array<Promise<AlgorithmResult>> = populationScenarios.map((populationScenario) => {
 
       return run(
         {

--- a/src/algorithms/test/run.test.tsx
+++ b/src/algorithms/test/run.test.tsx
@@ -42,23 +42,23 @@ describe('run()', () => {
   })
 
   it('should work for a lot of countries', async () => {
-
     const countryAgeDistributionWithType = countryAgeDistribution as CountryAgeDistribution
 
     const results: Array<Promise<AlgorithmResult>> = populationScenarios.map((populationScenario) => {
-
       return run(
         {
-          ...populationScenario!.data,
+          ...populationScenario.data,
           ...epidemiologicalScenarios[1].data,
           ...simulationData,
         },
         severityData,
-        countryAgeDistributionWithType[populationScenario!.data.country],
+        countryAgeDistributionWithType[populationScenario.data.country],
         containmentScenarios[3].data.reduction,
       )
     })
 
-    await Promise.all(results)
+    const finished = await Promise.all(results)
+
+    expect(finished).toHaveLength(results.length)
   })
 })


### PR DESCRIPTION
## Description

The country name label "United States" has been changed to "United States of America", but the field was not updates in the unit test. This PR addresses that fragility. With this PR we simply run all the population scenarios. It measures the same functionality, but removes the need to sync data labels in the unit test.

## Related issues

The breaking change was introduced in 5594f13007f9f95b854a8a60efb0af0dc314dd42

## Impacted Areas in the application

Unit tests.

## Testing

`yarn test:lint src/algorithms/test/run.test.tsx`
