### PR TITLE
#101/Remove the CountryAgeDistribution type from incompatible shape.

### DIFF
--- a/src/algorithms/test-data/ageDistribution.small.example.ts
+++ b/src/algorithms/test-data/ageDistribution.small.example.ts
@@ -1,6 +1,4 @@
-import { CountryAgeDistribution } from '../../assets/data/CountryAgeDistribution.types'
-
-const countryAgeDistribution: CountryAgeDistribution = {
+const countryAgeDistribution = {
   country: {
     'Germany': [
       3846778,


### PR DESCRIPTION
## Description

The file [`src/algorithms/test-data/ageDistribution.small.example.ts`](/neherlab/covid19_scenarios/tree/master/src/algorithms/test-data/ageDistribution.small.example.ts) exports a data structure typed as `CountryAgeDistribution`, but the linter warns that it does not match the shape. This PR removes the type assignment.

(The file doesn't appear to be used anymore – should it be deleted?)

## Related issues

#101 

## Impacted Areas in the application

Unknown

## Testing

`yarn test:lint`
