### PR TITLE
fix: add a command to close the disclaimer on each pages, update navigation test to not rely on language

### DIFF
--- a/cypress/integration/navigation.spec.ts
+++ b/cypress/integration/navigation.spec.ts
@@ -6,7 +6,8 @@ context('The navigation bar', () => {
   const navLinks = Object.entries(links)
 
   beforeEach(() => {
-    cy.visit(Cypress.env('BASE_URL'));
+    cy.visit(Cypress.env('BASE_URL'))
+    cy.closeDisclaimer()
   })
 
   it(`should have ${navLinks.length} links`, () => {
@@ -15,12 +16,13 @@ context('The navigation bar', () => {
       .should('have.length', navLinks.length)
   })
 
-  navLinks.forEach(([url, text]) => {
-    describe(`Clicking on "${text}" link`, () => {
+  navLinks.forEach(([url, _]) => {
+    describe(`Clicking on "${url}" link`, () => {
       it(`should open the ${url} page correctly`, () => {
         cy.findByTestId('NavigationBar')
-          .findByText(text)
+          .get(`[href="${url}"]`).first()
           .click()
+
         cy.location('pathname')
           .should('include', url)
       })

--- a/cypress/integration/results.spec.ts
+++ b/cypress/integration/results.spec.ts
@@ -5,6 +5,7 @@ const resultsCharts = ['DeterministicLinePlot', 'AgeBarChart', 'OutcomeRatesTabl
 context('The results card', () => {
   beforeEach(() => {
     cy.visit(Cypress.env('BASE_URL'))
+    cy.closeDisclaimer()
   })
 
   describe('RunResults', () => {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -25,3 +25,13 @@
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 
 import '@testing-library/cypress/add-commands';
+
+Cypress.Commands.add('closeDisclaimer', () => {
+  cy.findByText('COVID-19 Scenario Disclaimer')
+    .should('exist')
+    .next()
+    .click()
+
+  cy.findByText('COVID-19 Scenario Disclaimer')
+    .should('not.exist')
+});

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="cypress" />
+
+declare namespace Cypress {
+  interface Chainable {
+    closeDisclaimer: () => void;
+  }
+}


### PR DESCRIPTION
## Description
With the introduction of i18n, the navigation bar now gets his content from the i18next. On the test, the content is now undefined because at the time we get the content of the links the translation is not made. This is not necessary since we only care about the link url being correct.
- update the test to rely on the url

Second issue is the introduction of the disclaimer popup, it breaks the tests because the area we ry to interact with are below the modal's overlay.
- add a command to close the popup automatically

## Related issues
 - Contributes to #19 

## Testing
run `yarn e2e` or `yarn e2e:dev`
![covid-test](https://user-images.githubusercontent.com/6505742/77515955-d4b8a880-6ebc-11ea-8512-a58091d1de76.png)
