### PR TITLE
this fixes the plots in different language

### DIFF
--- a/src/components/Main/Results/DeterministicLinePlot.tsx
+++ b/src/components/Main/Results/DeterministicLinePlot.tsx
@@ -101,6 +101,7 @@ export function DeterministicLinePlot({ data, userResult, logScale, showHumanize
     hospitalized: caseCounts?.filter((d) => d.hospitalized).length ?? 0,
   }
 
+
   const observations =
     caseCounts?.map((d, i) => ({
       time: new Date(d.time).getTime(),
@@ -164,6 +165,7 @@ export function DeterministicLinePlot({ data, userResult, logScale, showHumanize
     ? Math.max(plotData[plotData.length - 1].time, observations[observations.length - 1].time)
     : plotData[plotData.length - 1].time
 
+
   const scatterToPlot: LineProps[] = observations.length
     ? [
         // Append empirical data
@@ -185,7 +187,7 @@ export function DeterministicLinePlot({ data, userResult, logScale, showHumanize
       ]
     : []
 
-  const logScaleString: YAxisProps['scale'] = logScale ? t('log') : t('linear')
+  const logScaleString: YAxisProps['scale'] = logScale ? 'log' : 'linear'
 
   const tooltipFormatter = (
     value: string | number | Array<string | number>,


### PR DESCRIPTION
## Related issues and PRs
Fixes #199 -- problem was that the scale keyword for plots was translated. 
 - 

## Description
make plots on log scale show in all languages.

## Impacted Areas in the application
results plot.


## Testing
only affects rendering out output. 
