### PR TITLE
internationalize number display

### DIFF
--- a/src/components/Main/Results/AgeBarChart.tsx
+++ b/src/components/Main/Results/AgeBarChart.tsx
@@ -10,7 +10,7 @@ import { AlgorithmResult } from '../../../algorithms/types/Result.types'
 
 import { SeverityTableRow } from '../Scenario/SeverityTable'
 
-import * as d3 from 'd3'
+import { numberFormatter } from '../../../helpers/numberFormat'
 
 import { colors } from './DeterministicLinePlot'
 
@@ -22,14 +22,14 @@ export interface SimProps {
   rates?: SeverityTableRow[]
 }
 
-const humanizeFormatter = d3.format('.5~s')
-
 export function AgeBarChart({ showHumanized, data, rates }: SimProps) {
-  const { t: unsafeT } = useTranslation()
+  const { t: unsafeT, i18n } = useTranslation()
 
   if (!data || !rates) {
     return null
   }
+
+  const formatNumber = numberFormatter(i18n.language, !!showHumanized, false)
 
   const t = (...args: Parameters<typeof unsafeT>) => {
     const translation = unsafeT(...args)
@@ -57,9 +57,9 @@ export function AgeBarChart({ showHumanized, data, rates }: SimProps) {
     name: string,
     entry: TooltipPayload,
     index: number,
-  ) => <span>{showHumanized ? humanizeFormatter(Number(value)) : value}</span>
+  ) => <span>{formatNumber(Number(value))}</span>
 
-  const tickFormatter = (value: number) => (showHumanized ? humanizeFormatter(value) : value)
+  const tickFormatter = (value: number) => formatNumber(value)
 
   return (
     <div className="w-100 h-100" data-testid="AgeBarChart">

--- a/src/components/Main/Results/DeterministicLinePlot.tsx
+++ b/src/components/Main/Results/DeterministicLinePlot.tsx
@@ -6,8 +6,7 @@ import type { LineProps as RechartsLineProps, YAxisProps } from 'recharts'
 import { useTranslation } from 'react-i18next'
 import { AlgorithmResult, UserResult } from '../../../algorithms/types/Result.types'
 import { EmpiricalData } from '../../../algorithms/types/Param.types'
-
-import * as d3 from 'd3'
+import { numberFormatter } from '../../../helpers/numberFormat'
 
 import './DeterministicLinePlot.scss'
 
@@ -64,8 +63,6 @@ interface LineProps {
   legendType?: RechartsLineProps['legendType']
 }
 
-const humanizeFormatter = d3.format('.5~s')
-
 function xTickFormatter(tick: string | number): string {
   return new Date(tick).toISOString().slice(0, 10)
 }
@@ -80,7 +77,9 @@ function legendFormatter(enabledPlots: string[], value: string, entry: any) {
 }
 
 export function DeterministicLinePlot({ data, userResult, logScale, showHumanized, caseCounts }: LinePlotProps) {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
+
+  const formatNumber = numberFormatter(i18n.language, !!showHumanized, false)
 
   const [enabledPlots, setEnabledPlots] = useState(Object.values(DATA_POINTS))
 
@@ -192,9 +191,9 @@ export function DeterministicLinePlot({ data, userResult, logScale, showHumanize
     name: string,
     entry: TooltipPayload,
     index: number,
-  ): React.ReactNode => <span>{showHumanized ? humanizeFormatter(Number(value)) : value}</span>
+  ): React.ReactNode => <span>{formatNumber(Number(value))}</span>
 
-  const yTickFormatter = (value: number) => (showHumanized ? humanizeFormatter(value) : value)
+  const yTickFormatter = (value: number) => formatNumber(value)
 
   return (
     <div className="w-100 h-100" data-testid="DeterministicLinePlot">

--- a/src/components/Main/Results/OutcomeRatesTable.tsx
+++ b/src/components/Main/Results/OutcomeRatesTable.tsx
@@ -10,6 +10,8 @@ import { AlgorithmResult } from '../../../algorithms/types/Result.types'
 
 import { SeverityTableRow } from '../Scenario/SeverityTable'
 
+import { numberFormatter } from '../../../helpers/numberFormat'
+
 export interface TableProps {
   showHumanized?: boolean
   result?: AlgorithmResult
@@ -17,15 +19,15 @@ export interface TableProps {
 }
 
 const percentageFormatter = (v: number) => d3.format('.2f')(v * 100)
-const humanizeFormatter = d3.format('.5s')
-const decimalFormatter = d3.format('d')
 
 export function OutcomeRatesTable({ showHumanized, result, rates }: TableProps) {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
 
   if (!result || !rates) {
     return null
   }
+
+  const formatNumber = numberFormatter(i18n.language, !!showHumanized, true)
 
   /*
   // FIXME: This looks like a prefix sum. Should we use `Array.reduce()` or a library instead?
@@ -62,7 +64,7 @@ export function OutcomeRatesTable({ showHumanized, result, rates }: TableProps) 
     Math.max(...result.deterministicTrajectory.map((x) => x.critical.total + x.overflow.total)),
   )
 
-  const totalFormatter = (value: number) => (showHumanized ? humanizeFormatter(value) : decimalFormatter(value))
+  const totalFormatter = (value: number) => formatNumber(value)
 
   // TODO: replace this with the table component (similar to severity table)
   return (

--- a/src/helpers/numberFormat.ts
+++ b/src/helpers/numberFormat.ts
@@ -1,0 +1,6 @@
+export function numberFormatter(language: string | undefined, humanize: boolean, round: boolean) {
+  return new Intl.NumberFormat(language, {
+    ...(humanize ? { notation: 'compact', compactDisplay: 'short' } : {}),
+    ...(round ? { maximumFractionDigits: 0 } : {}),
+  }).format
+}

--- a/src/types/Intl.d.ts
+++ b/src/types/Intl.d.ts
@@ -1,0 +1,10 @@
+// merge missing fields for Intl.NumberFormatOptions
+// https://github.com/microsoft/TypeScript/issues/36533
+
+// eslint-disable-next-line @typescript-eslint/tslint/config
+namespace Intl {
+  interface NumberFormatOptions {
+    notation?: string
+    compactDisplay?: string
+  }
+}


### PR DESCRIPTION
## Related issues and PRs

Fixes #198 

## Description

- Always internationalize numbers
- Optionally 'humanize' them
- Keep the total number rounding in the outcomes table when numbers are non humanized

## Impacted Areas in the application

Number display

## Testing

Check numbers on axis and tooltips.

@rcbevans can you check this? Thanks!