### PR TITLE
do not round outcome rates when compacting them

### DIFF
--- a/src/components/LanguageSwitcher/index.tsx
+++ b/src/components/LanguageSwitcher/index.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { Dropdown, DropdownToggle, DropdownMenu, DropdownItem } from 'reactstrap'
 import i18next from 'i18next'
+import * as d3 from 'd3'
 
 import langs, { Lang as LangType } from '../../langs'
 
@@ -46,6 +47,7 @@ export default function LanguageSwitcher() {
               i18next.changeLanguage(langs[key].lang, () => {
                 localStorage.setItem('lang', langs[key].lang)
               })
+              d3.formatDefaultLocale(langs[key].d3Locale)
             }}
           >
             <Lang lang={langs[key]} />

--- a/src/components/LanguageSwitcher/index.tsx
+++ b/src/components/LanguageSwitcher/index.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import { Dropdown, DropdownToggle, DropdownMenu, DropdownItem } from 'reactstrap'
 import i18next from 'i18next'
 
-import langs from '../../langs'
+import langs, { Lang as LangType } from '../../langs'
 
 import './LanguageSwitcher.scss'
 
@@ -24,7 +24,7 @@ export function getCurrentLang(): string {
  * Flag next?
  * @param lang
  */
-function Lang({ lang }: { lang: Lang }) {
+function Lang({ lang }: { lang: LangType }) {
   return <span className="language-switcher-lang">{lang.name}</span>
 }
 

--- a/src/components/Main/Results/AgeBarChart.tsx
+++ b/src/components/Main/Results/AgeBarChart.tsx
@@ -23,13 +23,13 @@ export interface SimProps {
 }
 
 export function AgeBarChart({ showHumanized, data, rates }: SimProps) {
-  const { t: unsafeT, i18n } = useTranslation()
+  const { t: unsafeT } = useTranslation()
 
   if (!data || !rates) {
     return null
   }
 
-  const formatNumber = numberFormatter(i18n.language, !!showHumanized, false)
+  const formatNumber = numberFormatter(!!showHumanized, !showHumanized)
 
   const t = (...args: Parameters<typeof unsafeT>) => {
     const translation = unsafeT(...args)

--- a/src/components/Main/Results/DeterministicLinePlot.tsx
+++ b/src/components/Main/Results/DeterministicLinePlot.tsx
@@ -77,9 +77,9 @@ function legendFormatter(enabledPlots: string[], value: string, entry: any) {
 }
 
 export function DeterministicLinePlot({ data, userResult, logScale, showHumanized, caseCounts }: LinePlotProps) {
-  const { t, i18n } = useTranslation()
+  const { t } = useTranslation()
 
-  const formatNumber = numberFormatter(i18n.language, !!showHumanized, false)
+  const formatNumber = numberFormatter(!!showHumanized, !showHumanized)
 
   const [enabledPlots, setEnabledPlots] = useState(Object.values(DATA_POINTS))
 
@@ -99,7 +99,6 @@ export function DeterministicLinePlot({ data, userResult, logScale, showHumanize
     newCases: caseCounts?.filter((d, i) => i > 2 && d.cases && caseCounts[i - 3].cases).length ?? 0,
     hospitalized: caseCounts?.filter((d) => d.hospitalized).length ?? 0,
   }
-
 
   const observations =
     caseCounts?.map((d, i) => ({
@@ -163,7 +162,6 @@ export function DeterministicLinePlot({ data, userResult, logScale, showHumanize
   const tMax = observations.length
     ? Math.max(plotData[plotData.length - 1].time, observations[observations.length - 1].time)
     : plotData[plotData.length - 1].time
-
 
   const scatterToPlot: LineProps[] = observations.length
     ? [

--- a/src/components/Main/Results/OutcomeRatesTable.tsx
+++ b/src/components/Main/Results/OutcomeRatesTable.tsx
@@ -27,7 +27,7 @@ export function OutcomeRatesTable({ showHumanized, result, rates }: TableProps) 
     return null
   }
 
-  const formatNumber = numberFormatter(i18n.language, !!showHumanized, true)
+  const formatNumber = numberFormatter(i18n.language, !!showHumanized, !showHumanized)
 
   /*
   // FIXME: This looks like a prefix sum. Should we use `Array.reduce()` or a library instead?

--- a/src/components/Main/Results/OutcomeRatesTable.tsx
+++ b/src/components/Main/Results/OutcomeRatesTable.tsx
@@ -21,13 +21,13 @@ export interface TableProps {
 const percentageFormatter = (v: number) => d3.format('.2f')(v * 100)
 
 export function OutcomeRatesTable({ showHumanized, result, rates }: TableProps) {
-  const { t, i18n } = useTranslation()
+  const { t } = useTranslation()
 
   if (!result || !rates) {
     return null
   }
 
-  const formatNumber = numberFormatter(i18n.language, !!showHumanized, !showHumanized)
+  const formatNumber = numberFormatter(!!showHumanized, !showHumanized)
 
   /*
   // FIXME: This looks like a prefix sum. Should we use `Array.reduce()` or a library instead?

--- a/src/helpers/numberFormat.ts
+++ b/src/helpers/numberFormat.ts
@@ -1,6 +1,6 @@
-export function numberFormatter(language: string | undefined, humanize: boolean, round: boolean) {
+export function numberFormatter(language: string | undefined, compact: boolean, round: boolean) {
   return new Intl.NumberFormat(language, {
-    ...(humanize ? { notation: 'compact', compactDisplay: 'short' } : {}),
+    ...(compact ? { notation: 'compact', compactDisplay: 'short', maximumFractionDigits: 2 } : {}),
     ...(round ? { maximumFractionDigits: 0 } : {}),
   }).format
 }

--- a/src/helpers/numberFormat.ts
+++ b/src/helpers/numberFormat.ts
@@ -1,6 +1,14 @@
-export function numberFormatter(language: string | undefined, compact: boolean, round: boolean) {
-  return new Intl.NumberFormat(language, {
-    ...(compact ? { notation: 'compact', compactDisplay: 'short', maximumFractionDigits: 2 } : {}),
-    ...(round ? { maximumFractionDigits: 0 } : {}),
-  }).format
+import * as d3 from 'd3'
+
+export function numberFormatter(humanize: boolean, round: boolean) {
+  let formatString = ',.2f'
+  if (humanize && round) {
+    throw new Error('not implemented')
+  } else if (humanize) {
+    formatString = ',.3~s'
+  } else if (round) {
+    formatString = ',.0f'
+  }
+
+  return d3.format(formatString)
 }

--- a/src/langs.ts
+++ b/src/langs.ts
@@ -1,28 +1,41 @@
+import { FormatLocaleDefinition } from 'd3-format'
+import enLocale from 'd3-format/locale/en-US.json'
+import frLocale from 'd3-format/locale/fr-FR.json'
+import ptLocale from 'd3-format/locale/pt-BR.json'
+import deLocale from 'd3-format/locale/de-DE.json'
+import esLocale from 'd3-format/locale/es-ES.json'
+
 export type Lang = {
   lang: string
   name: string
+  d3Locale: FormatLocaleDefinition
 }
 
 const langs: { [key: string]: Lang } = {
   en: {
     lang: 'en',
     name: 'english',
+    d3Locale: enLocale as FormatLocaleDefinition,
   },
   fr: {
     lang: 'fr',
     name: 'français',
+    d3Locale: frLocale as FormatLocaleDefinition,
   },
   pt: {
     lang: 'pt',
     name: 'português',
+    d3Locale: ptLocale as FormatLocaleDefinition,
   },
   de: {
     lang: 'de',
     name: 'deutsch',
+    d3Locale: deLocale as FormatLocaleDefinition,
   },
   es: {
     lang: 'es',
     name: 'español',
+    d3Locale: esLocale as FormatLocaleDefinition,
   },
 }
 

--- a/src/langs.ts
+++ b/src/langs.ts
@@ -1,4 +1,4 @@
-type Lang = {
+export type Lang = {
   lang: string
   name: string
 }


### PR DESCRIPTION
## Related issues and PRs

Fix #198 & resolves #210 regression where 1667132.485331003 became 2M.

## Description

Do not round the values in the outcome rates table if they are being displayed in a humanly readable compact form. When the human form causes truncation use 2 fraction digits. e.g. 1667132.485331003 becomes 1.67M for locale "en".

Do round them otherwise.

And always i18n them.

## Impacted Areas in the application

Number display

## Testing

Look at the numbers!