### PR TITLE
Feat: Responsive tooltips

### DIFF
--- a/src/components/Main/Results/AgeBarChart.tsx
+++ b/src/components/Main/Results/AgeBarChart.tsx
@@ -14,6 +14,9 @@ import { numberFormatter } from '../../../helpers/numberFormat'
 
 import { colors } from './DeterministicLinePlot'
 
+import { calculatePosition, scrollToRef } from './chartHelper'
+import { ResponsiveTooltipContent } from './ResponsiveTooltipContent'
+
 const ASPECT_RATIO = 16 / 4
 
 export interface SimProps {
@@ -24,7 +27,9 @@ export interface SimProps {
 
 export function AgeBarChart({ showHumanized, data, rates }: SimProps) {
   const { t: unsafeT } = useTranslation()
-
+  const casesChartRef = React.useRef(null)
+  const percentageChartRef = React.useRef(null)
+  
   if (!data || !rates) {
     return null
   }
@@ -71,11 +76,15 @@ export function AgeBarChart({ showHumanized, data, rates }: SimProps) {
           }
 
           const height = Math.max(250, width / ASPECT_RATIO)
+          const tooltipPosition = calculatePosition(height)
 
           return (
             <>
               <h5>{t('Distribution across age groups')}</h5>
+
+              <div ref={casesChartRef} />
               <BarChart
+                onClick={() => scrollToRef(casesChartRef)}
                 width={width}
                 height={height}
                 data={plotData}
@@ -91,7 +100,10 @@ export function AgeBarChart({ showHumanized, data, rates }: SimProps) {
                   label={{ value: t('Cases'), angle: -90, position: 'insideLeft' }}
                   tickFormatter={tickFormatter}
                 />
-                <Tooltip formatter={tooltipFormatter} />
+                <Tooltip 
+                  position={tooltipPosition} 
+                  content={ResponsiveTooltipContent}
+                />
                 <Legend verticalAlign="top" />
                 <CartesianGrid strokeDasharray="3 3" />
                 <Bar dataKey="peakSevere" fill={colors.severe} name={t('peak severe')} />
@@ -99,7 +111,10 @@ export function AgeBarChart({ showHumanized, data, rates }: SimProps) {
                 <Bar dataKey="peakOverflow" fill={colors.overflow} name={t('peak overflow')} />
                 <Bar dataKey="totalFatalities" fill={colors.fatality} name={t('total deaths')} />
               </BarChart>
+
+              <div ref={percentageChartRef} />
               <BarChart
+                onClick={() => scrollToRef(percentageChartRef)}
                 width={width}
                 height={height}
                 data={plotData}
@@ -119,7 +134,10 @@ export function AgeBarChart({ showHumanized, data, rates }: SimProps) {
                   }}
                 />
                 <CartesianGrid strokeDasharray="3 3" />
-                <Tooltip />
+                <Tooltip 
+                  position={tooltipPosition} 
+                  content={ResponsiveTooltipContent}
+                />
                 <Bar dataKey="fraction" fill="#aaaaaa" name={t('% of total')} />
               </BarChart>
             </>

--- a/src/components/Main/Results/DeterministicLinePlot.tsx
+++ b/src/components/Main/Results/DeterministicLinePlot.tsx
@@ -8,6 +8,9 @@ import { AlgorithmResult, UserResult } from '../../../algorithms/types/Result.ty
 import { EmpiricalData } from '../../../algorithms/types/Param.types'
 import { numberFormatter } from '../../../helpers/numberFormat'
 
+import { calculatePosition, scrollToRef } from './chartHelper'
+import { ResponsiveTooltipContent } from './ResponsiveTooltipContent'
+
 import './DeterministicLinePlot.scss'
 
 const ASPECT_RATIO = 16 / 9
@@ -81,6 +84,8 @@ export function DeterministicLinePlot({ data, userResult, logScale, showHumanize
 
   const formatNumber = numberFormatter(!!showHumanized, false)
   const formatNumberRounded = numberFormatter(!!showHumanized, true)
+
+  const chartRef = React.useRef(null)
 
   const [enabledPlots, setEnabledPlots] = useState(Object.values(DATA_POINTS))
 
@@ -209,11 +214,15 @@ export function DeterministicLinePlot({ data, userResult, logScale, showHumanize
           }
 
           const height = Math.max(500, width / ASPECT_RATIO)
+          const tooltipPosition = calculatePosition(height)
 
           return (
             <>
               <h5>{t('Cases through time')}</h5>
+              
+              <div ref={chartRef} />
               <ComposedChart
+                onClick={() => scrollToRef(chartRef)}
                 width={width}
                 height={height}
                 data={plotData}
@@ -234,7 +243,11 @@ export function DeterministicLinePlot({ data, userResult, logScale, showHumanize
                   tickCount={7}
                 />
                 <YAxis scale={logScaleString} type="number" domain={[1, 'dataMax']} tickFormatter={yTickFormatter} />
-                <Tooltip formatter={tooltipFormatter} labelFormatter={labelFormatter} />
+                <Tooltip 
+                  formatter={tooltipFormatter} 
+                  position={tooltipPosition} 
+                  content={ResponsiveTooltipContent}
+                />
                 <Legend
                   verticalAlign="top"
                   formatter={(v, e) => legendFormatter(enabledPlots, v, e)}

--- a/src/components/Main/Results/DeterministicLinePlot.tsx
+++ b/src/components/Main/Results/DeterministicLinePlot.tsx
@@ -245,6 +245,7 @@ export function DeterministicLinePlot({ data, userResult, logScale, showHumanize
                 <YAxis scale={logScaleString} type="number" domain={[1, 'dataMax']} tickFormatter={yTickFormatter} />
                 <Tooltip 
                   formatter={tooltipFormatter} 
+                  labelFormatter={labelFormatter}
                   position={tooltipPosition} 
                   content={ResponsiveTooltipContent}
                 />

--- a/src/components/Main/Results/ResponsiveTooltipContent.scss
+++ b/src/components/Main/Results/ResponsiveTooltipContent.scss
@@ -1,0 +1,32 @@
+.responsive-tooltip-content-base {
+  padding: 0.25rem;
+  border: 1px solid rgba(0, 0, 0, 0.5);
+  z-index: 999;
+  background-color: white;
+}
+
+.responsive-tooltip-content {
+  display: flex;
+  flex-direction: column;
+}
+
+.responsive-tooltip-content-item {
+  padding: 0.25rem 0.6rem;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.responsive-tooltip-content-placeholder {
+  min-width: 1rem;
+}
+
+@media screen and (max-width: 992px) {
+  .responsive-tooltip-content {
+    display: grid;
+    grid-template: 1fr / 1fr 1fr;
+    max-width: 90vw;
+  }
+}
+

--- a/src/components/Main/Results/ResponsiveTooltipContent.tsx
+++ b/src/components/Main/Results/ResponsiveTooltipContent.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import './ResponsiveTooltipContent.scss'
+
+interface TooltipItem {
+  name: string
+  value: string | number
+  color: string
+}
+
+interface TooltipContentProps {
+  active: boolean,
+  label: string | number
+  payload: TooltipItem[]
+} 
+
+function ToolTipContentItem({ name, value, color}: TooltipItem) {
+  return (
+    <div style={{ color }} className="responsive-tooltip-content-item">
+      {name}
+      <div className="responsive-tooltip-content-placeholder" />
+      {value}
+    </div>
+  )
+}
+
+export function ResponsiveTooltipContent({ active, payload, label }: TooltipContentProps) {
+  const formattedLabel = Number(label) > 10000 ? new Date(label).toISOString().slice(0, 10) : label
+
+  const essentialPayload = payload.map(payloadItem => ({
+    name: payloadItem.name,
+    color: payloadItem.color || '#bbbbbb',
+    value: payloadItem.value
+  }))
+
+  const left = payload.length > 1 ? essentialPayload.slice(0, Math.floor(payload.length / 2)) : payload
+  const right = payload.length > 1 ? essentialPayload.slice(Math.floor(payload.length / 2), payload.length - 1) : []
+
+  if (active) {
+    return (
+      <div className="responsive-tooltip-content-base">
+        <strong>{formattedLabel}</strong>
+        <div className="responsive-tooltip-content">
+          <div>
+            {left.map((item, idx) => <ToolTipContentItem key={idx} name={item.name} value={item.value} color={item.color} />)}
+          </div>
+          <div>
+            {right.map((item, idx) => <ToolTipContentItem key={idx} name={item.name} value={item.value} color={item.color} />)}
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  return null
+}

--- a/src/components/Main/Results/ResponsiveTooltipContent.tsx
+++ b/src/components/Main/Results/ResponsiveTooltipContent.tsx
@@ -12,7 +12,8 @@ interface TooltipContentProps {
   active: boolean,
   label: string | number
   payload: TooltipItem[]
-  formatter?: any
+  formatter?: Function
+  labelFormatter?: Function
 } 
 
 function ToolTipContentItem({ name, value, color}: TooltipItem) {
@@ -25,8 +26,8 @@ function ToolTipContentItem({ name, value, color}: TooltipItem) {
   )
 }
 
-export function ResponsiveTooltipContent({ active, payload, label, formatter }: TooltipContentProps) {
-  const formattedLabel = Number(label) > 10000 ? new Date(label).toISOString().slice(0, 10) : label
+export function ResponsiveTooltipContent({ active, payload, label, formatter, labelFormatter }: TooltipContentProps) {
+  const formattedLabel = labelFormatter && label ? labelFormatter(label) : label
   const formatNumber = formatter
 
   const essentialPayload = payload.map(payloadItem => ({

--- a/src/components/Main/Results/ResponsiveTooltipContent.tsx
+++ b/src/components/Main/Results/ResponsiveTooltipContent.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+
 import './ResponsiveTooltipContent.scss'
 
 interface TooltipItem {
@@ -11,6 +12,7 @@ interface TooltipContentProps {
   active: boolean,
   label: string | number
   payload: TooltipItem[]
+  formatter?: any
 } 
 
 function ToolTipContentItem({ name, value, color}: TooltipItem) {
@@ -23,13 +25,14 @@ function ToolTipContentItem({ name, value, color}: TooltipItem) {
   )
 }
 
-export function ResponsiveTooltipContent({ active, payload, label }: TooltipContentProps) {
+export function ResponsiveTooltipContent({ active, payload, label, formatter }: TooltipContentProps) {
   const formattedLabel = Number(label) > 10000 ? new Date(label).toISOString().slice(0, 10) : label
+  const formatNumber = formatter
 
   const essentialPayload = payload.map(payloadItem => ({
     name: payloadItem.name,
     color: payloadItem.color || '#bbbbbb',
-    value: payloadItem.value
+    value: formatter ? formatNumber(payloadItem.value, '', '', 0) : payloadItem.value
   }))
 
   const left = payload.length > 1 ? essentialPayload.slice(0, Math.floor(payload.length / 2)) : payload

--- a/src/components/Main/Results/chartHelper.ts
+++ b/src/components/Main/Results/chartHelper.ts
@@ -1,0 +1,18 @@
+import { MutableRefObject } from 'react'
+
+const singleColumnThreshold = 992
+
+export function calculatePosition(height: number) {
+  const yPosition = window.innerWidth < singleColumnThreshold ? height - 20 : null
+
+  if (window.innerWidth < singleColumnThreshold) return { x: 0, y: yPosition }
+  else return { y: yPosition }
+}
+
+export function scrollToRef(ref: MutableRefObject<any>) {
+  if (window.innerWidth < singleColumnThreshold) {
+    ref.current.scrollIntoView({
+      behavior: 'smooth'
+    })
+  }
+}

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -110,3 +110,7 @@ input[type='number']::-webkit-outer-spin-button {
 .btn:disabled {
   cursor: not-allowed;
 }
+
+.recharts-tooltip-wrapper {
+  z-index: 999;
+}


### PR DESCRIPTION
All right, here's a fixed PR discussed here: [#157](https://github.com/neherlab/covid19_scenarios/pull/157)

There was some weirdness with rebasing. So this PR should only deal with my changes, which include:

- Custom ResponsiveTooltipContent component, which will divide in two columns on mobile for better readability.
- Repositioning of the chart Tooltip component when in single column mode.
- When clicking on chart in single column mode, the page scrolls the chart to top, so that repositioned Tooltip is wholly visible.

@ivan-aksamentov if you're happy with this you can merge.