### PR TITLE
testing/Compare interpolated values using isCloseTo() instead of snapshot.

### DIFF
--- a/src/algorithms/test/TimeSeries.test.ts
+++ b/src/algorithms/test/TimeSeries.test.ts
@@ -101,7 +101,24 @@ describe('TimeSeries', () => {
         return interpolator(date)
       })
 
-      expect(result).toBeArrayOfSize(intervalCount).toMatchSnapshot()
+      expect(result).toBeArrayOfSize(intervalCount)
+
+      const expected = [
+        1,
+        2.6354594390679185,
+        4.209836664611696,
+        5.648965995858905,
+        6.892037521792783,
+        7.889772449043392,
+        8.678773876200733,
+        9.32431394905387,
+        9.891684813683101,
+        10,
+      ]
+
+      result.forEach((y, index) => {
+        expect(y).toBeCloseTo(expected[index])
+      })
     })
   })
 

--- a/src/algorithms/test/__snapshots__/TimeSeries.test.ts.snap
+++ b/src/algorithms/test/__snapshots__/TimeSeries.test.ts.snap
@@ -1,20 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TimeSeries interpolateTimeSeries() interpolation within the timerange occurs as expected. 1`] = `
-Array [
-  1,
-  2.6354594390679185,
-  4.205626732055542,
-  5.645209732882576,
-  6.888916295468725,
-  7.8873202652312076,
-  8.676811131585438,
-  9.322659276563021,
-  9.89015684624425,
-  10,
-]
-`;
-
 exports[`TimeSeries updateTimeSeries() interpolates an existing TimeSeries with a new "y" vector. 1`] = `
 Array [
   Object {


### PR DESCRIPTION
## Related issues and PRs

#194 

## Description

The `TimeSeries.test.ts` test _'interpolation within the timerange occurs as expected'_ fails sometimes on some machines. The test uses a snapshot to compare floating point values. This PR extracts the expected values from the snapshot, inlines them into the test, and compares them to the results using Jest's .isCloseTo() assertion.

## Impacted Areas in the application

TimeSeries unit tests.

## Testing

`yarn test:lint TimeSeries`
