### PR TITLE
Add description meta tag

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -7,6 +7,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
+    <meta name="description" content="This tool uses a mathematical model to simulate a variety of COVID-19 outcomes based on user-defined parameters"/>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Related issues and PRs

Contributes to #106 

## Description

This PR adds the missing meta tag "description" to the HTML, that's a improvement for SEO based on the lighthouse audit report:

![image](https://user-images.githubusercontent.com/9062864/77781310-a4584200-7055-11ea-953f-ea9f0ddc301e.png)


## Impacted Areas in the application

`src/index.ejs`


## Testing

Open the browser, run a report using lighthouse with SEO option marked.
