### PR TITLE
Added localstorage hooks for autorun, log scales, and show humanized results settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "typescript-fsa-reducers": "1.2.1",
     "url-join": "4.0.1",
     "use-debounce": "3.4.0",
+    "use-persisted-state": "0.3.0",
     "yup": "0.28.3"
   },
   "devDependencies": {
@@ -169,6 +170,7 @@
     "@types/terser-webpack-plugin": "2.2.0",
     "@types/testing-library__cypress": "5.0.3",
     "@types/url-join": "4.0.0",
+    "@types/use-persisted-state": "0.3.0",
     "@types/webpack": "4.41.7",
     "@types/webpack-bundle-analyzer": "2.13.3",
     "@types/webpackbar": "2.6.0",

--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -1,11 +1,9 @@
 import React, { useReducer, useState, useEffect } from 'react'
 import { useDebouncedCallback } from 'use-debounce'
-
 import _ from 'lodash'
-
 import { Form, Formik, FormikHelpers } from 'formik'
-
 import { Col, Row } from 'reactstrap'
+import createPersistedState from 'use-persisted-state'
 
 import { SeverityTableRow } from './Scenario/SeverityTable'
 
@@ -86,9 +84,11 @@ const isRegion = (region: string): region is keyof typeof countryCaseCountData =
   return countryCaseCountData.hasOwnProperty(region)
 }
 
+const useAutorunSimulationState = createPersistedState('autorunSimulation')
+
 function Main() {
   const [result, setResult] = useState<AlgorithmResult | undefined>()
-  const [autorunSimulation, setAutorunSimulation] = useState(false)
+  const [autorunSimulation, setAutorunSimulation] = useAutorunSimulationState(false)
   const [scenarioState, scenarioDispatch] = useReducer(
     scenarioReducer,
     defaultScenarioState,

--- a/src/components/Main/Results/ResultsCard.tsx
+++ b/src/components/Main/Results/ResultsCard.tsx
@@ -2,6 +2,7 @@ import Papa from 'papaparse'
 import React, { createRef, useEffect, useState } from 'react'
 import { Button, Col, Row } from 'reactstrap'
 import { useTranslation } from 'react-i18next'
+import createPersistedState from 'use-persisted-state'
 
 import ExportSimulationDialog from './ExportSimulationDialog'
 import FormSwitch from '../../Form/FormSwitch'
@@ -16,6 +17,9 @@ import { FileType } from '../Compare/FileUploadZone'
 import { OutcomeRatesTable } from './OutcomeRatesTable'
 import { readFile } from '../../../helpers/readFile'
 import { SeverityTableRow } from '../Scenario/SeverityTable'
+
+const useLogScaleState = createPersistedState('logScale')
+const useShowHumanizedState = createPersistedState('showHumanized')
 
 import './ResultsCard.scss'
 
@@ -37,8 +41,8 @@ function ResultsCardFunction({
   caseCounts,
 }: ResultsCardProps) {
   const { t } = useTranslation()
-  const [logScale, setLogScale] = useState(true)
-  const [showHumanized, setShowHumanized] = useState(true)
+  const [logScale, setLogScale] = useLogScaleState(true)
+  const [showHumanized, setShowHumanized] = useShowHumanizedState(true)
 
   // TODO: shis should probably go into the `Compare/`
   const [files, setFiles] = useState<Map<FileType, File>>(new Map())

--- a/yarn.lock
+++ b/yarn.lock
@@ -2500,6 +2500,13 @@
   resolved "https://registry.yarnpkg.com/@types/url-join/-/url-join-4.0.0.tgz#72eff71648a429c7d4acf94e03780e06671369bd"
   integrity sha512-awrJu8yML4E/xTwr2EMatC+HBnHGoDxc2+ImA9QyeUELI1S7dOCIZcyjki1rkwoA8P2D2NVgLAJLjnclkdLtAw==
 
+"@types/use-persisted-state@0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@types/use-persisted-state/-/use-persisted-state-0.3.0.tgz#23370e89bd6c8468afdb05dde2d1bab898128229"
+  integrity sha512-ZT98QuckR95qM7W97lGVqc7fFS9TT6f3txp7R40fl0zxa5BLm3GG7j0i51G12h8DkoJxFAf2oQyYKU99h0pxFA==
+  dependencies:
+    "@types/react" "*"
+
 "@types/vfile-message@*":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/vfile-message/-/vfile-message-2.0.0.tgz#690e46af0fdfc1f9faae00cd049cc888957927d5"
@@ -2660,6 +2667,11 @@
     lodash "^4.17.15"
     semver "^6.3.0"
     tsutils "^3.17.1"
+
+"@use-it/event-listener@^0.1.2":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@use-it/event-listener/-/event-listener-0.1.3.tgz#a9920b2819d211cf55e68e830997546eec6886d3"
+  integrity sha512-UCHkLOVU+xj3/1R8jXz8GzDTowkzfIDPESOBlVC2ndgwUSBEqiFdwCoUEs2lcGhJOOiEdmWxF+T23C5+60eEew==
 
 "@webassemblyjs/ast@1.8.5":
   version "1.8.5"
@@ -15783,6 +15795,13 @@ use-debounce@3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/use-debounce/-/use-debounce-3.4.0.tgz#e61653fd4daad9beaa6e4695bc1d3fbd35f7e5b3"
   integrity sha512-FSUfs/x7eJUusqvbk/UboMlWKQFBEGTegqK2tvm8+59bcbs77f0DeAy4MuychfxN7E+6rxXDpbv41Kq+aSJPow==
+
+use-persisted-state@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/use-persisted-state/-/use-persisted-state-0.3.0.tgz#f8e3d2fd8eee67e0c86fd596c3ea3e8121c07402"
+  integrity sha512-UlWEq0JYg7NbvcRBZ1g6Bwe4SEbYfr1wr/D5mrmfCzSxXSwsPRYygGLlsxHcW58Rf7gGwRPBT23sNVvyVn4WYg==
+  dependencies:
+    "@use-it/event-listener" "^0.1.2"
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
## Related issues and PRs
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->
 - Fixes #215 
- Relates to #214 

## Description
To make the following user settings persistent using the browser's local storage:
* Toggle autorun
* Log scales
* Show humanized results

## Impacted Areas in the application
<!-- Components of the application that this PR will change -->
* Main.tsx
* ResultsCard.tsx

## Testing
<!-- Steps to test the changes proposed by this PR -->
Open the site, toggle a UI setting, such as auto run, log graphs and show humanize. Refresh the page, observe that your UI preference is restored.