### PR TITLE
Set an upper limit on eslint warnings so that more cannot be merged

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_script:
 
 script:
   - yarn test:nowatch
-  - yarn eslint --max-warnings 113 || (echo ERROR New eslint errors were introduced by these changes && exit 1)
+  - yarn eslint --max-warnings 114 || (echo ERROR New eslint errors were introduced by these changes && exit 1)
 
 before_deploy:
   - yarn prod

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ before_script:
 
 script:
   - yarn test:nowatch
+  - yarn eslint --max-warnings 113
 
 before_deploy:
   - yarn prod

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_script:
 
 script:
   - yarn test:nowatch
-  - yarn eslint --max-warnings 113 || (echo "ERROR: New eslint errors were introduced by these changes" && exit 1)
+  - yarn eslint --max-warnings 113 || (echo ERROR New eslint errors were introduced by these changes && exit 1)
 
 before_deploy:
   - yarn prod

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_script:
 
 script:
   - yarn test:nowatch
-  - yarn eslint --max-warnings 114
+  - yarn eslint --max-warnings 113 || (echo "ERROR: New eslint errors were introduced by these changes" && exit 1)
 
 before_deploy:
   - yarn prod

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_script:
 
 script:
   - yarn test:nowatch
-  - yarn eslint --max-warnings 113
+  - yarn eslint --max-warnings 114
 
 before_deploy:
   - yarn prod


### PR DESCRIPTION
## Related issues and PRs

Contributes to #101

## Description

There are currently 114 eslint warnings. With this change future PRs will not be able to increase that count. The goal would be to gradually reduce this high water number as lint errors are fixed until an eslint warning free codebase is reached 🎉 

## Impacted Areas in the application

Lintiness.

## Testing

This PR has an initial max count of 113 which should fail travis CI. Then I'll change it and it should pass.