### PR TITLE
Fix regression 'interpolation within the timerange occurs as expected.'

### DIFF
--- a/src/algorithms/utils/TimeSeries.test.ts
+++ b/src/algorithms/utils/TimeSeries.test.ts
@@ -91,7 +91,28 @@ describe('TimeSeries', () => {
         return interpolator(date)
       })
 
-      expect(result).toBeArrayOfSize(intervalCount).toMatchSnapshot()
+      expect(result).toBeArrayOfSize(intervalCount)
+
+      /* toMatchSnapshot() doesn't work well with floating point numbers.
+       * So we need to manually iterate and assert using toBeCloseTo().
+       */
+
+      const expected = [
+        1,
+        2.6354594390679185,
+        4.209836664611696,
+        5.648965995858905,
+        6.892037521792783,
+        7.889772449043392,
+        8.678773876200733,
+        9.32431394905387,
+        9.891684813683101,
+        10,
+      ]
+
+      result.forEach((y, index) => {
+        expect(y).toBeCloseTo(expected[index])
+      })
     })
   })
 

--- a/src/algorithms/utils/__snapshots__/TimeSeries.test.ts.snap
+++ b/src/algorithms/utils/__snapshots__/TimeSeries.test.ts.snap
@@ -1,20 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TimeSeries interpolateTimeSeries() interpolation within the timerange occurs as expected. 1`] = `
-Array [
-  1,
-  2.6354594390679185,
-  4.205626732055542,
-  5.645209732882576,
-  6.888916295468725,
-  7.8873202652312076,
-  8.676811131585438,
-  9.322659276563021,
-  9.89015684624425,
-  10,
-]
-`;
-
 exports[`TimeSeries updateTimeSeries() interpolates an existing TimeSeries with a new "y" vector. 1`] = `
 Array [
   Object {


### PR DESCRIPTION

## Related issues and PRs

This regression was previously fixed in #238 

## Description

The TimeSeries.test.ts `'interpolation within the timerange occurs as expected.'` test fails sometimes.

<img width="798" alt="image" src="https://user-images.githubusercontent.com/1462268/77832199-94e70080-710a-11ea-82f9-3e19d480f8c8.png">

The test uses toMatchSnapshot(), which compares the results using string representations.
The test is fixed by instead comparing the arrays using toBeCloseTo() assertions.

## Impacted Areas in the application

TimeSeries.test.ts unit tests.

## Testing

`yarn test:lint TimeSeries`
