### PR TITLE
[CSS] Make text and icons in charts align verticall

### DIFF
--- a/src/components/Main/Results/DeterministicLinePlot.scss
+++ b/src/components/Main/Results/DeterministicLinePlot.scss
@@ -1,6 +1,5 @@
 .legend {
   cursor: pointer;
-  vertical-align: middle;
 }
 
 .legend-inactive {

--- a/src/components/Main/Results/DeterministicLinePlot.scss
+++ b/src/components/Main/Results/DeterministicLinePlot.scss
@@ -1,5 +1,6 @@
 .legend {
   cursor: pointer;
+  vertical-align: middle;
 }
 
 .legend-inactive {

--- a/src/components/Main/Results/ResultsCard.scss
+++ b/src/components/Main/Results/ResultsCard.scss
@@ -8,3 +8,7 @@
     display: none;
   }
 }
+
+.recharts-legend-item-text {
+  vertical-align: middle;
+}


### PR DESCRIPTION
## Related issues and PRs
- Contributes to #83

## Description
Aims to align the text and icon of the ResultCards legends so it looks cleaner

## Impacted Areas in the application
ResultsCard

## Testing
Visually tested, screenshot:
![image](https://user-images.githubusercontent.com/55852795/77832708-454a0a00-70f5-11ea-8a5b-e7c5d2e64999.png)

