### PR TITLE
#101/Add "arrowParens": "always" to prettier config.

### DIFF
--- a/config/.prettierrc
+++ b/config/.prettierrc
@@ -4,5 +4,6 @@
   "quoteProps": "consistent",
   "semi": false,
   "singleQuote": true,
-  "trailingComma": "all"
+  "trailingComma": "all",
+  "arrowParens": "always"
 }


### PR DESCRIPTION


## Related issues and PRs
#101 , #260 

## Description

The linter is configured to want parens around arrow function parameters, but Prettier was not configured to add them. Consequently there are regressions like #260. This PR fixes that.

## Impacted Areas in the application

Linting

## Testing

Edit a source file. Try to create an arrow function without parenthesized parameters. Your editor should automatically add the parentheses.
