### PR TITLE
#274/WIP Implement a Jest extension to compare arrays of floats to snapshots.

### DIFF
--- a/src/algorithms/utils/TimeSeries.test.ts
+++ b/src/algorithms/utils/TimeSeries.test.ts
@@ -1,6 +1,106 @@
 import { uniformDatesBetween, makeTimeSeries, updateTimeSeries } from './TimeSeries'
 import { interpolateTimeSeries } from '../run'
 
+import * as fs from 'fs'
+const { utils } = require('jest-snapshot')
+
+expect.extend({
+  toBeCloseToArraySnapshot(received: number[]) {
+    const { testPath, currentTestName, snapshotState } = this
+    snapshotState._counters.set(currentTestName, (snapshotState._counters.get(currentTestName) || 0) + 1)
+    const count = Number(snapshotState._counters.get(currentTestName))
+    const key = utils.testNameToKey(currentTestName, count)
+    const expected = snapshotState._snapshotData[key]
+
+    /* If this isn't done, Jest reports the test as 'obsolete' and prompts for deletion. */
+    snapshotState._uncheckedKeys.delete(key)
+
+    /* If the snapshot isn't JSON, then return an empty array. Otherwise
+     * the test will fails in an inscrutable way.
+     */
+    const tryParse = (str: string) => {
+      try {
+        return JSON.parse(str)
+      } catch (e) {
+        return []
+      }
+    }
+
+    /* If the expected field is blank, then this is probably a new snapshot. */
+    const expectedDeserialized = expected ? tryParse(expected) : []
+
+    const pass =
+      expectedDeserialized.length > 0 /* must check this because every() returns true if empty array */
+        ? received.every((_, idx) => Math.abs(expectedDeserialized[idx] - received[idx]) < 10 ** -2 / 2)
+        : false
+    const hasSnapshot = expected !== undefined
+    const snapshotIsPersisted = fs.existsSync(snapshotState._snapshotPath)
+    const receivedSerialized = JSON.stringify(received, null, 2)
+
+    if (pass) {
+      /* Test passed, now update the snapshot state with the serialize snapshot.
+       * Technically this is only necessary if no snapshot was saved before. */
+      snapshotState._snapshotData[key] = receivedSerialized
+    }
+
+    /* This nested mess is derived the Jest snapshot matcher code:
+     * https://github.com/facebook/jest/blob/4a59daa8715bde6a1b085ff7f4140f3a337045aa/packages/jest-snapshot/src/State.ts
+     */
+    if (
+      (hasSnapshot && snapshotState._updateSnapshot === 'all') ||
+      ((!hasSnapshot || !snapshotIsPersisted) &&
+        (snapshotState._updateSnapshot === 'new' || snapshotState._updateSnapshot === 'all'))
+    ) {
+      if (snapshotState._updateSnapshot === 'all') {
+        if (!pass) {
+          if (hasSnapshot) {
+            snapshotState.updated++
+          } else {
+            snapshotState.added++
+          }
+          snapshotState._addSnapshot(key, receivedSerialized, { error: undefined, isInline: false })
+        } else {
+          snapshotState.matched++
+        }
+      } else {
+        snapshotState._addSnapshot(key, receivedSerialized, { error: undefined, isInline: false })
+        snapshotState.added++
+      }
+
+      return {
+        message: () => 'message a',
+        actual: '',
+        count,
+        expected: '',
+        key,
+        pass: true,
+      }
+    } else {
+      if (!pass) {
+        snapshotState.unmatched++
+        return {
+          message: () => 'message b',
+          actual: receivedSerialized,
+          count,
+          expected: expected !== undefined ? expected : undefined,
+          key,
+          pass: false,
+        }
+      } else {
+        snapshotState.matched++
+        return {
+          message: () => 'message c',
+          actual: receivedSerialized,
+          count,
+          expected: '',
+          key,
+          pass: true,
+        }
+      }
+    }
+  },
+})
+
 describe('TimeSeries', () => {
   const tMin = new Date('1970-10-01T00:00:00.000Z')
   const tMax = new Date('1971-02-01T00:00:00.000Z')
@@ -91,7 +191,8 @@ describe('TimeSeries', () => {
         return interpolator(date)
       })
 
-      expect(result).toBeArrayOfSize(intervalCount).toMatchSnapshot()
+      expect(result).toBeArrayOfSize(intervalCount)
+      expect(result).toBeCloseToArraySnapshot()
     })
   })
 

--- a/src/algorithms/utils/TimeSeries.test.ts
+++ b/src/algorithms/utils/TimeSeries.test.ts
@@ -6,7 +6,7 @@ const { utils } = require('jest-snapshot')
 
 expect.extend({
   toBeCloseToArraySnapshot(received: number[]) {
-    const { testPath, currentTestName, snapshotState } = this
+    const { currentTestName, snapshotState } = this
     snapshotState._counters.set(currentTestName, (snapshotState._counters.get(currentTestName) || 0) + 1)
     const count = Number(snapshotState._counters.get(currentTestName))
     const key = utils.testNameToKey(currentTestName, count)

--- a/src/algorithms/utils/__snapshots__/TimeSeries.test.ts.snap
+++ b/src/algorithms/utils/__snapshots__/TimeSeries.test.ts.snap
@@ -1,19 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TimeSeries interpolateTimeSeries() interpolation within the timerange occurs as expected. 1`] = `
-Array [
+exports[`TimeSeries interpolateTimeSeries() interpolation within the timerange occurs as expected. 1`] = `[
   1,
   2.6354594390679185,
-  4.205626732055542,
-  5.645209732882576,
-  6.888916295468725,
-  7.8873202652312076,
-  8.676811131585438,
-  9.322659276563021,
-  9.89015684624425,
-  10,
-]
-`;
+  4.209836664611696,
+  5.648965995858905,
+  6.892037521792783,
+  7.889772449043392,
+  8.678773876200733,
+  9.32431394905387,
+  9.891684813683101,
+  10
+]`;
 
 exports[`TimeSeries updateTimeSeries() interpolates an existing TimeSeries with a new "y" vector. 1`] = `
 Array [

--- a/src/types/jest.d.ts
+++ b/src/types/jest.d.ts
@@ -11,10 +11,16 @@ import 'jest-extended/types'
 import 'jest-chain'
 
 // tslint:disable-next-line:no-namespace
-namespace jest {
-  interface Matchers<R> {
-    // After toBeTruthy() we are certain that the matched value is not null.
-    // Modify the return type accordingly.
-    toBeTruthy(): NonNullable<R>
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      // After toBeTruthy() we are certain that the matched value is not null.
+      // Modify the return type accordingly.
+      toBeTruthy(): NonNullable<R>
+    }
+
+    interface ChainedMatchers<R> {
+      toBeCloseToArraySnapshot(values: number[]): R
+    }
   }
 }


### PR DESCRIPTION
## Related issues and PRs

Addresses concerns raised in #274 by implementing #281.

## Description

Jest snapshots are very useful because they can be updated from the test runner UI. But the default Jest snapshot assertion compares serialized strings. That causes problems if floats need to be compared. This PR implements a custom snapshot matcher for arrays of float values. It works by serializing expected results as a JSON array into the snapshot file. The snapshot can be deserialized and checked using a loop of toBeCloseTo() assertions. With this extension algorithm developers can use the Jest UI to add/update/remove snapshot results without modifying test logic.

This is a hack – it touches internal, private, Jest state. No guarantee this will continue to work if Jest is upgraded.

## Impacted Areas in the application

Unit tests

## Testing

`yarn test TimeSeries`
