### PR TITLE
#101/Lint and style all things Cypress

### DIFF
--- a/cypress/integration/navigation.spec.ts
+++ b/cypress/integration/navigation.spec.ts
@@ -11,20 +11,15 @@ context('The navigation bar', () => {
   })
 
   it(`should have ${navLinks.length} links`, () => {
-    cy.findByTestId('NavigationBar')
-      .get('.nav-link')
-      .should('have.length', navLinks.length)
+    cy.findByTestId('NavigationBar').get('.nav-link').should('have.length', navLinks.length)
   })
 
   navLinks.forEach(([url, _]: [string, any]) => {
     describe(`Clicking on "${url}" link`, () => {
       it(`should open the ${url} page correctly`, () => {
-        cy.findByTestId('NavigationBar')
-          .get(`[href="${url}"]`).first()
-          .click()
+        cy.findByTestId('NavigationBar').get(`[href="${url}"]`).first().click()
 
-        cy.location('pathname')
-          .should('include', url)
+        cy.location('pathname').should('include', url)
       })
     })
   })

--- a/cypress/integration/navigation.spec.ts
+++ b/cypress/integration/navigation.spec.ts
@@ -14,7 +14,7 @@ context('The navigation bar', () => {
     cy.findByTestId('NavigationBar').get('.nav-link').should('have.length', navLinks.length)
   })
 
-  navLinks.forEach(([url, _]: [string, any]) => {
+  navLinks.forEach((url: string) => {
     describe(`Clicking on "${url}" link`, () => {
       it(`should open the ${url} page correctly`, () => {
         cy.findByTestId('NavigationBar').get(`[href="${url}"]`).first().click()

--- a/cypress/integration/results.spec.ts
+++ b/cypress/integration/results.spec.ts
@@ -27,17 +27,17 @@ context('The results card', () => {
 
   describe('results charts', () => {
     it('should have default invisible charts', () => {
-      for (const testId of resultsCharts) {
+      resultsCharts.forEach((testId) => {
         cy.findByTestId(testId).should('be.not.visible')
-      }
+      })
     })
 
     it('should become visible charts after clicking RunResults button', () => {
       cy.findByTestId('RunResults').click()
 
-      for (const testId of resultsCharts) {
+      resultsCharts.forEach((testId) => {
         cy.findByTestId(testId).should('be.visible')
-      }
+      })
     })
   })
 })

--- a/cypress/integration/results.spec.ts
+++ b/cypress/integration/results.spec.ts
@@ -16,13 +16,13 @@ context('The results card', () => {
 
   describe('LogScaleSwitch', () => {
     it('should be invisible by default', () => {
-      cy.findByTestId('LogScaleSwitch').should('be.not.visible');
-    });
+      cy.findByTestId('LogScaleSwitch').should('be.not.visible')
+    })
 
     it('should become visible after clicking RunResults button', () => {
       cy.findByTestId('RunResults').click()
-      cy.findByTestId('LogScaleSwitch').should('be.visible');
-    });
+      cy.findByTestId('LogScaleSwitch').should('be.visible')
+    })
   })
 
   describe('results charts', () => {

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -17,7 +17,7 @@ import webpack from '@cypress/webpack-preprocessor'
 /**
  * @type {Cypress.PluginConfig}
  */
-module.exports = (on, config) => {
+module.exports = (on) => {
   const options = {
     webpackOptions: {
       module: {

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -25,15 +25,15 @@ module.exports = (on, config) => {
           {
             test: /\.tsx?$/,
             use: 'babel-loader',
-            exclude: /node_modules/
-          }
-        ]
+            exclude: /node_modules/,
+          },
+        ],
       },
       resolve: {
-        extensions: ['.ts', '.tsx', '.js']
-      }
+        extensions: ['.ts', '.tsx', '.js'],
+      },
     },
-    watchOptions: {}
+    watchOptions: {},
   }
 
   on('file:preprocessor', webpack(options))

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -12,7 +12,7 @@
 // This function is called when a project is opened or re-opened (e.g. due to
 // the project's config changing)
 
-const webpack = require('@cypress/webpack-preprocessor')
+import webpack from '@cypress/webpack-preprocessor'
 
 /**
  * @type {Cypress.PluginConfig}

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -24,14 +24,10 @@
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 
-import '@testing-library/cypress/add-commands';
+import '@testing-library/cypress/add-commands'
 
 Cypress.Commands.add('closeDisclaimer', () => {
-  cy.findByText('COVID-19 Scenario Disclaimer')
-    .should('exist')
-    .next()
-    .click()
+  cy.findByText('COVID-19 Scenario Disclaimer').should('exist').next().click()
 
-  cy.findByText('COVID-19 Scenario Disclaimer')
-    .should('not.exist')
-});
+  cy.findByText('COVID-19 Scenario Disclaimer').should('not.exist')
+})

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -2,6 +2,6 @@
 
 declare namespace Cypress {
   interface Chainable {
-    closeDisclaimer: () => void;
+    closeDisclaimer: () => void
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -104,7 +104,8 @@
     "react-a11y-accessible-headings": false,
     "react-this-binding-issue": false,
     "underscore-consistent-invocation": false,
-    "use-simple-attributes": false
+    "use-simple-attributes": false,
+    "no-namespace": [true, "allow-declarations"]
   },
   "linterOptions": {
     "exclude": [


### PR DESCRIPTION
## Related issues and PRs
#101  😬

## Description

This PR fixes all the prettier+lint warning in the `cypress/` folder. It's a large PR, but confined to a single folder and built of atomic commits.

## Impacted Areas in the application

Linting and style warnings for all source code in the `cypress/` folder.


## Testing

Manually check the style rules for `cypress/` only:
`npx eslint --report-unused-disable-directives --format codeframe "cypress/**/*.{js,jsx,ts,ts,json}"`
