### PR TITLE
#287/fix e2e tests with landing page

### DIFF
--- a/cypress/integration/language.spec.ts
+++ b/cypress/integration/language.spec.ts
@@ -35,18 +35,15 @@ context('Language switcher', () => {
         .first()
         .click()
 
-      cy.findByTestId('LanguageSwitcher')
-        .should('not.have.class', 'show')
+      cy.findByTestId('LanguageSwitcher').should('not.have.class', 'show')
     })
 
     it(`should have ${availableLangs.length} languages`, () => {
-      cy.findByTestId('LanguageSwitcher')
-        .get('[role="menu"] button')
-        .should('have.length', availableLangs.length)
+      cy.findByTestId('LanguageSwitcher').get('[role="menu"] button').should('have.length', availableLangs.length)
     })
   })
 
-  availableLangs.forEach(([key, value]: [string, { lang: string, name: string }]) => {
+  availableLangs.forEach(([key, value]: [string, { lang: string; name: string }]) => {
     describe(`Switching to "${value.name}"`, () => {
       it(`should change the language to "${value.lang}" correctly`, () => {
         cy.findByTestId('LanguageSwitcher')
@@ -57,12 +54,9 @@ context('Language switcher', () => {
           .findByText(value.name)
           .click()
 
-        cy.findByTestId('LanguageSwitcher')
-          .get('.dropdown-toggle')
-          .should('have.text', value.name)
+        cy.findByTestId('LanguageSwitcher').get('.dropdown-toggle').should('have.text', value.name)
 
-        cy.findByTestId('ResultsCardTitle')
-          .should('have.text', languageMap[key])
+        cy.findByTestId('ResultsCardTitle').should('have.text', languageMap[key])
       })
     })
   })

--- a/cypress/integration/language.spec.ts
+++ b/cypress/integration/language.spec.ts
@@ -3,17 +3,19 @@
 import langs from '../../src/langs'
 
 const availableLangs = Object.entries(langs)
-const languageMap: {[key: string]: string} = {
+const languageMap: { [key: string]: string } = {
   en: 'Results',
   fr: 'Resultats',
   pt: 'Resultados',
   de: 'Ergebnisse',
-  es: 'Resultados'
+  es: 'Resultados',
+  pl: 'Wyniki',
 }
 
 context('Language switcher', () => {
   before(() => {
     cy.visit(Cypress.env('BASE_URL'))
+    cy.closeLanding()
     cy.closeDisclaimer()
   })
 

--- a/cypress/integration/navigation.spec.ts
+++ b/cypress/integration/navigation.spec.ts
@@ -7,6 +7,7 @@ context('The navigation bar', () => {
 
   beforeEach(() => {
     cy.visit(Cypress.env('BASE_URL'))
+    cy.closeLanding()
     cy.closeDisclaimer()
   })
 
@@ -14,7 +15,7 @@ context('The navigation bar', () => {
     cy.findByTestId('NavigationBar').get('.nav-link').should('have.length', navLinks.length)
   })
 
-  navLinks.forEach((url: string) => {
+  navLinks.forEach(([url]: string) => {
     describe(`Clicking on "${url}" link`, () => {
       it(`should open the ${url} page correctly`, () => {
         cy.findByTestId('NavigationBar').get(`[href="${url}"]`).first().click()

--- a/cypress/integration/results.spec.ts
+++ b/cypress/integration/results.spec.ts
@@ -5,6 +5,7 @@ const resultsCharts = ['DeterministicLinePlot', 'AgeBarChart', 'OutcomeRatesTabl
 context('The results card', () => {
   beforeEach(() => {
     cy.visit(Cypress.env('BASE_URL'))
+    cy.closeLanding()
     cy.closeDisclaimer()
   })
 

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -12,7 +12,8 @@
 // This function is called when a project is opened or re-opened (e.g. due to
 // the project's config changing)
 
-import webpack from '@cypress/webpack-preprocessor'
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const webpack = require('@cypress/webpack-preprocessor')
 
 /**
  * @type {Cypress.PluginConfig}

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -26,6 +26,10 @@
 
 import '@testing-library/cypress/add-commands'
 
+Cypress.Commands.add('closeLanding', () => {
+  cy.get('#go-simulate').click()
+})
+
 Cypress.Commands.add('closeDisclaimer', () => {
   cy.findByText('COVID-19 Scenario Disclaimer').should('exist').next().click()
 

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -3,5 +3,6 @@
 declare namespace Cypress {
   interface Chainable {
     closeDisclaimer: () => void
+    closeLanding: () => void
   }
 }

--- a/src/components/LandingPage/LandingPage.tsx
+++ b/src/components/LandingPage/LandingPage.tsx
@@ -33,6 +33,7 @@ function LandingPage() {
           </div>
           <Link
             onClick={onLinkClick}
+            id="go-simulate"
             to="/"
             className="landing-page__simulate-link"
           >


### PR DESCRIPTION
## Related issues and PRs

#287, #288 

## Description

This gets all the e2e tests running green. Apologies for barging in and duplicating work in #288 – this PR incorporates the prettier+linting fixes from #296.

## Impacted Areas in the application

E2E tests.


## Testing

1. Start a dev server: `yarn dev`, and leave it running.
2. Run the e2e tests: `yarn e2e:dev`