### PR TITLE
fix: update e2e tests to close the starting screen, add polish to language switcher test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 node_modules
 tools/__pycache__
 cypress/videos/
+cypress/screenshots/

--- a/cypress/integration/language.spec.ts
+++ b/cypress/integration/language.spec.ts
@@ -8,7 +8,8 @@ const languageMap: {[key: string]: string} = {
   fr: 'Resultats',
   pt: 'Resultados',
   de: 'Ergebnisse',
-  es: 'Resultados'
+  es: 'Resultados',
+  pl: 'Wyniki',
 }
 
 context('Language switcher', () => {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -27,6 +27,12 @@
 import '@testing-library/cypress/add-commands';
 
 Cypress.Commands.add('closeDisclaimer', () => {
+  cy.url()
+    .should('include', '/start')
+
+  cy.get('.landing-page__simulate-link')
+    .click()
+
   cy.findByText('COVID-19 Scenario Disclaimer')
     .should('exist')
     .next()


### PR DESCRIPTION
## Related issues and PRs
The e2e tests are broken after addition of a new language and a starting page.

## Description
Fix the e2e tests
Add new tests for new language and new page

## Impacted Areas in the application
E2E tests

## Testing
`yarn e2e`
![Capture d’écran de 2020-03-30 16-05-12](https://user-images.githubusercontent.com/6505742/77884571-49665b00-72a0-11ea-8e79-7c22665cd421.png)
