### PR TITLE
validation of numberPoints in reducer

### DIFF
--- a/src/components/Main/state/reducer.ts
+++ b/src/components/Main/state/reducer.ts
@@ -90,11 +90,16 @@ export const scenarioReducer = reducerWithInitialState(defaultScenarioState)
 
   .withHandling(
     immerCase(setContainmentData, (draft, { data }) => {
+      let validNumberPoints = draft.data.containment.numberPoints
+      if (data.numberPoints && data.numberPoints >= 5 && data.numberPoints <= 100) {
+        validNumberPoints = data.numberPoints
+      }
+
       draft.scenarios = maybeAdd(draft.scenarios, CUSTOM_SCENARIO_NAME)
       draft.current = CUSTOM_SCENARIO_NAME
       draft.data.containment = {
-        reduction: updateTimeSeries(draft.data.simulation.simulationTimeRange, data.reduction, data.numberPoints),
-        numberPoints: data.numberPoints,
+        reduction: updateTimeSeries(draft.data.simulation.simulationTimeRange, data.reduction, validNumberPoints),
+        numberPoints: validNumberPoints,
       }
     }),
   )


### PR DESCRIPTION


## Related issues and PRs
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->
 - fixes #307 

## Description
<!-- Goal of the pull request -->

formik Field updates field value even when outside specified
min-max range (e.g. when updating with keyboard, not with arrows).
This allows for null value of numberPoints, or for value outside
desired 5-100 range, which may lead to 'Containment cannot be
empty' error in algorithms/run.ts. Added aditional validation
of numberPoints value in the reducer.

## Impacted Areas in the application
<!-- Components of the application that this PR will change -->

Behavior of mitigation curve when editing number of points with keyboard (it will not change when number of points is not within 5-100 range).

## Testing
<!-- Steps to test the changes proposed by this PR -->

Try removing value of number of points with keyboard, or setting value which is not in the 5-100 range, mitigation curve should not change.
