### PR TITLE
compare just number of points in callback

### DIFF
--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -152,9 +152,14 @@ function Main() {
     if (!_.isEqual(allParams.simulation, newParams.simulation)) {
       scenarioDispatch(setSimulationData({ data: newParams.simulation }))
     }
-    // NOTE: deep object comparison!
-    if (!_.isEqual(allParams.containment, newParams.containment)) {
-      scenarioDispatch(setContainmentData({ data: newParams.containment }))
+    // NOTE: compare only value controlled by formik!
+    if (allParams.containment.numberPoints !== newParams.containment.numberPoints) {
+      scenarioDispatch(setContainmentData({
+        data: {
+          reduction: allParams.containment.reduction,
+          numberPoints: newParams.containment.numberPoints
+        }
+      }))
     }
   }, 1000)
 


### PR DESCRIPTION
## Related issues and PRs
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->
 - fixes #315 

## Description
<!-- Goal of the pull request -->

fixes bug which results in point on mitigation curve returning
to initial position after number of points has been changed

## Impacted Areas in the application
<!-- Components of the application that this PR will change -->

behavior of mitigation widget after changing number of points

## Testing
<!-- Steps to test the changes proposed by this PR -->

check if moved point on mitigation curve stays in position after number of points has been changed