### PR TITLE
fix wrong variable name in tsv export

### DIFF
--- a/src/algorithms/model.ts
+++ b/src/algorithms/model.ts
@@ -489,7 +489,7 @@ export function exportSimulation(result: UserResult) {
   const headerCumulative = keys(result.trajectory[0].cumulative)
   const tsvHeaderCumulative = headerCumulative.map((x) => `cumulative_${x}`)
 
-  const tsv = [`time\t${tsv_header.concat(tsvHeaderCumulative).join('\t')}`]
+  const tsv = [`time\t${tsvHeader.concat(tsvHeaderCumulative).join('\t')}`]
 
   const pop: Record<string, boolean> = {}
   result.trajectory.forEach((d) => {


### PR DESCRIPTION
## Description
Trivial PR. Fixing a leftover variable renaming. 

## Impacted Areas in the application
export. Now works again. 
