### PR TITLE
filter empty data points to improve auto axis scaling in plot

### DIFF
--- a/src/components/Main/Results/DeterministicLinePlot.tsx
+++ b/src/components/Main/Results/DeterministicLinePlot.tsx
@@ -106,8 +106,8 @@ export function DeterministicLinePlot({ data, userResult, logScale, showHumanize
   // this currently relies on there being data for every day. This should be
   // the case given how the data are parsed, but would be good to put in a check
   const newCases = (cc: EmpiricalData, i: number) => {
-    if (i >= caseStep && nonEmptyCaseCounts[i].cases && nonEmptyCaseCounts[i - caseStep].cases) {
-      return verifyPositive(nonEmptyCaseCounts[i].cases - nonEmptyCaseCounts[i - caseStep].cases)
+    if (i >= caseStep && cc[i].cases && cc[i - caseStep].cases) {
+      return verifyPositive(cc[i].cases - cc[i - caseStep].cases)
     }
     return undefined
   }

--- a/src/components/Main/Results/DeterministicLinePlot.tsx
+++ b/src/components/Main/Results/DeterministicLinePlot.tsx
@@ -127,7 +127,7 @@ export function DeterministicLinePlot({ data, userResult, logScale, showHumanize
         ? d.hospitalized || undefined
         : undefined,
       ICU: enabledPlots.includes(DATA_POINTS.ObservedICU) ? d.ICU || undefined : undefined,
-      newCases: enabledPlots.includes(DATA_POINTS.ObservedNewCases) ? newCases(caseCounts, i) : undefined,
+      newCases: enabledPlots.includes(DATA_POINTS.ObservedNewCases) ? newCases(nonEmptyCaseCounts, i) : undefined,
       hospitalBeds: nHospitalBeds,
       ICUbeds: nICUBeds,
     })) ?? []

--- a/src/components/Main/Results/DeterministicLinePlot.tsx
+++ b/src/components/Main/Results/DeterministicLinePlot.tsx
@@ -103,6 +103,8 @@ export function DeterministicLinePlot({ data, userResult, logScale, showHumanize
   const nonEmptyCaseCounts = caseCounts?.filter((d) => d.cases || d.deaths || d.ICU || d.hospitalized)
 
   const caseStep = 3
+  // this currently relies on there being data for every day. This should be
+  // the case given how the data are parsed, but would be good to put in a check
   const newCases = (cc: EmpiricalData, i: number) => {
     if (i >= caseStep && nonEmptyCaseCounts[i].cases && nonEmptyCaseCounts[i - caseStep].cases) {
       return verifyPositive(nonEmptyCaseCounts[i].cases - nonEmptyCaseCounts[i - caseStep].cases)

--- a/src/components/Main/Results/DeterministicLinePlot.tsx
+++ b/src/components/Main/Results/DeterministicLinePlot.tsx
@@ -100,16 +100,26 @@ export function DeterministicLinePlot({ data, userResult, logScale, showHumanize
   const nHospitalBeds = verifyPositive(data.params.hospitalBeds)
   const nICUBeds = verifyPositive(data.params.ICUBeds)
 
-  const count_observations = {
-    cases: caseCounts?.filter((d) => d.cases).length ?? 0,
-    ICU: caseCounts?.filter((d) => d.ICU).length ?? 0,
-    observedDeaths: caseCounts?.filter((d) => d.deaths).length ?? 0,
-    newCases: caseCounts?.filter((d, i) => i > 2 && d.cases && caseCounts[i - 3].cases).length ?? 0,
-    hospitalized: caseCounts?.filter((d) => d.hospitalized).length ?? 0,
+  const nonEmptyCaseCounts = caseCounts?.filter((d) => d.cases || d.deaths || d.ICU || d.hospitalized)
+
+  const caseStep = 3
+  const newCases = (cc: EmpiricalData, i: number) => {
+    if (i >= caseStep && nonEmptyCaseCounts[i].cases && nonEmptyCaseCounts[i - caseStep].cases) {
+      return verifyPositive(nonEmptyCaseCounts[i].cases - nonEmptyCaseCounts[i - caseStep].cases)
+    }
+    return undefined
+  }
+
+  const countObservations = {
+    cases: nonEmptyCaseCounts?.filter((d) => d.cases).length ?? 0,
+    ICU: nonEmptyCaseCounts?.filter((d) => d.ICU).length ?? 0,
+    observedDeaths: nonEmptyCaseCounts?.filter((d) => d.deaths).length ?? 0,
+    newCases: nonEmptyCaseCounts?.filter((d, i) => newCases(nonEmptyCaseCounts, i)).length ?? 0,
+    hospitalized: nonEmptyCaseCounts?.filter((d) => d.hospitalized).length ?? 0,
   }
 
   const observations =
-    caseCounts?.map((d, i) => ({
+    nonEmptyCaseCounts?.map((d, i) => ({
       time: new Date(d.time).getTime(),
       cases: enabledPlots.includes(DATA_POINTS.ObservedCases) ? d.cases || undefined : undefined,
       observedDeaths: enabledPlots.includes(DATA_POINTS.ObservedDeaths) ? d.deaths || undefined : undefined,
@@ -117,11 +127,7 @@ export function DeterministicLinePlot({ data, userResult, logScale, showHumanize
         ? d.hospitalized || undefined
         : undefined,
       ICU: enabledPlots.includes(DATA_POINTS.ObservedICU) ? d.ICU || undefined : undefined,
-      newCases: enabledPlots.includes(DATA_POINTS.ObservedNewCases)
-        ? i > 2
-          ? d.cases - caseCounts[i - 3].cases || undefined
-          : undefined
-        : undefined,
+      newCases: enabledPlots.includes(DATA_POINTS.ObservedNewCases) ? newCases(caseCounts, i) : undefined,
       hospitalBeds: nHospitalBeds,
       ICUbeds: nICUBeds,
     })) ?? []
@@ -176,19 +182,19 @@ export function DeterministicLinePlot({ data, userResult, logScale, showHumanize
   const scatterToPlot: LineProps[] = observations.length
     ? [
         // Append empirical data
-        ...(count_observations.observedDeaths
+        ...(countObservations.observedDeaths
           ? [{ key: DATA_POINTS.ObservedDeaths, color: colors.fatality, name: t('Cumulative confirmed deaths') }]
           : []),
-        ...(count_observations.cases
+        ...(countObservations.cases
           ? [{ key: DATA_POINTS.ObservedCases, color: colors.cumulativeCases, name: t('Cumulative confirmed cases') }]
           : []),
-        ...(count_observations.hospitalized
+        ...(countObservations.hospitalized
           ? [{ key: DATA_POINTS.ObservedHospitalized, color: colors.severe, name: t('Patients in hospital') }]
           : []),
-        ...(count_observations.ICU
+        ...(countObservations.ICU
           ? [{ key: DATA_POINTS.ObservedICU, color: colors.critical, name: t('Patients in ICU') }]
           : []),
-        ...(count_observations.newCases
+        ...(countObservations.newCases
           ? [{ key: DATA_POINTS.ObservedNewCases, color: colors.newCases, name: t('Confirmed cases past 3 days') }]
           : []),
       ]


### PR DESCRIPTION
## Related issues and PRs
This is related to #312  (already fixed) but catches more such problems. 
Also related to #154 

## Description
This PR abstracts our calculation of new cases and removes all empty data points from the graph. 


## Impacted Areas in the application
plot. 

## Testing
inspect output. biggest change is expected for Germany where the case counts include data starting Jan 1st. 
