### PR TITLE
fix: (ResponsiveTooltipContent) Making label optional

### DIFF
--- a/src/components/Main/Results/ResponsiveTooltipContent.tsx
+++ b/src/components/Main/Results/ResponsiveTooltipContent.tsx
@@ -10,7 +10,7 @@ interface TooltipItem {
 
 interface TooltipContentProps {
   active: boolean
-  label: string | number
+  label?: string | number
   payload: TooltipItem[]
   formatter?: Function
   labelFormatter?: Function

--- a/src/components/Main/Results/ResponsiveTooltipContent.tsx
+++ b/src/components/Main/Results/ResponsiveTooltipContent.tsx
@@ -1,10 +1,10 @@
-import React from 'react'
+import React, { ReactNode } from 'react'
 
 import './ResponsiveTooltipContent.scss'
 
 interface TooltipItem {
   name: string
-  value: string | number
+  value: string | number | ReactNode
   color: string
 }
 


### PR DESCRIPTION
## Related issues and PRs
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->
 - N/A

## Description
<!-- Goal of the pull request -->
Removing warninga in browser console, to reduce noise:

![Snag_3a030d62](https://user-images.githubusercontent.com/1078403/78058190-d46a5280-737f-11ea-9bfb-a52e95d86ef3.png)

![Snag_3a11ae03](https://user-images.githubusercontent.com/1078403/78059623-109eb280-7382-11ea-8a60-b53d28d8b10b.png)

## Impacted Areas in the application
<!-- Components of the application that this PR will change -->
ResponsiveTooltipContent.tsx

## Testing
<!-- Steps to test the changes proposed by this PR -->
Click the Run button, then hover over the graph to see the tooltip. No warnings shouldn't be present in browser console after applying this PR.

![error](https://user-images.githubusercontent.com/1078403/78058369-1c897500-7380-11ea-8eff-a90dc1aab099.png)
