### PR TITLE
Remove grid-gap

### DIFF
--- a/src/components/LandingPage/LandingPage.scss
+++ b/src/components/LandingPage/LandingPage.scss
@@ -116,7 +116,7 @@
   font-size: 12px;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 900px) {
   .landing-page__hero-section {
     min-height: 350px;
     padding: 40px 40px 10vw;

--- a/src/components/LandingPage/LandingPage.scss
+++ b/src/components/LandingPage/LandingPage.scss
@@ -17,7 +17,6 @@
   color: $white;
   background: linear-gradient(180deg, #206bbd 2%, rgba(249, 252, 255, 0) 80%),
     linear-gradient(180deg, #007bff00 5%, #007bff 80%);
-  grid-gap: 20px;
   grid-template-columns: 1fr auto 1fr;
 
   &::after {
@@ -61,6 +60,7 @@
   border-radius: 500px;
   align-self: end;
   justify-self: center;
+  margin: 0 20px;
   &:hover,
   &:focus {
     color: $black;


### PR DESCRIPTION
## Related issues and PRs

Fixes #321 

## Description

IE does not support `grid-gap` at IE10. 
https://medium.com/@elad/supporting-css-grid-in-internet-explorer-b38669e75d66

Removed it added a margin on the inner column and noticed no difference.

Also fixed some text overlap with the app image at widths <900>768.

## Impacted Areas in the application

Landing page

## Testing

Viewed the landing page at various widths.
