### PR TITLE
Switch numeral to numbro

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "lodash": "4.17.15",
     "mathjs": "6.6.1",
     "moment": "2.24.0",
-    "numeral": "2.0.6",
+    "numbro": "2.2.0",
     "p-min-delay": "3.1.0",
     "papaparse": "5.1.1",
     "prop-types": "15.7.2",

--- a/src/components/LanguageSwitcher/index.tsx
+++ b/src/components/LanguageSwitcher/index.tsx
@@ -2,20 +2,20 @@ import React, { useState } from 'react'
 import { Dropdown, DropdownToggle, DropdownMenu, DropdownItem } from 'reactstrap'
 import i18next from 'i18next'
 
-import langs, { Lang as LangType } from '../../langs'
+import SupportedLocales, { Locale, SupportedLocale } from '../../langs'
 
 import LocalStorage, { LOCAL_STORAGE_KEYS } from '../../helpers/localStorage'
 
 import './LanguageSwitcher.scss'
 
-const DEFAULT_LANG = 'en'
+const DEFAULT_LOCALE: SupportedLocale = 'en'
 
 /**
  * Returns our active lang loaded from localstorage
  */
-export function getCurrentLang(): string {
-  const storedLang = LocalStorage.get<string>(LOCAL_STORAGE_KEYS.LANG)
-  return storedLang ?? DEFAULT_LANG
+export function getCurrentLang(): SupportedLocale {
+  const storedLang = LocalStorage.get<SupportedLocale>(LOCAL_STORAGE_KEYS.LANG)
+  return storedLang ?? DEFAULT_LOCALE
 }
 
 /**
@@ -23,7 +23,7 @@ export function getCurrentLang(): string {
  * Flag next?
  * @param lang
  */
-function Lang({ lang }: { lang: LangType }) {
+function Lang({ lang }: { lang: Locale }) {
   return <span className="language-switcher-lang">{lang.name}</span>
 }
 
@@ -35,19 +35,19 @@ export default function LanguageSwitcher() {
   return (
     <Dropdown isOpen={dropdownOpen} toggle={toggle} className="pull-right" data-testid="LanguageSwitcher">
       <DropdownToggle caret>
-        <Lang lang={langs[selectedLang]} />
+        <Lang lang={SupportedLocales[selectedLang]} />
       </DropdownToggle>
       <DropdownMenu>
-        {Object.keys(langs).map((key) => (
+        {(Object.keys(SupportedLocales) as SupportedLocale[]).map((key: SupportedLocale) => (
           <DropdownItem
             key={key}
             onClick={() => {
-              i18next.changeLanguage(langs[key].lang, () => {
-                LocalStorage.set(LOCAL_STORAGE_KEYS.LANG, langs[key].lang)
+              i18next.changeLanguage(SupportedLocales[key].lang, () => {
+                LocalStorage.set(LOCAL_STORAGE_KEYS.LANG, SupportedLocales[key].lang)
               })
             }}
           >
-            <Lang lang={langs[key]} />
+            <Lang lang={SupportedLocales[key]} />
           </DropdownItem>
         ))}
       </DropdownMenu>

--- a/src/helpers/numberFormat.ts
+++ b/src/helpers/numberFormat.ts
@@ -3,8 +3,9 @@ import { numbro } from '../i18n'
 export function numberFormatter(humanize: boolean, round: boolean) {
   return (value: number) =>
     numbro(value).format({
-      average: humanize || undefined,
+      thousandSeparated: true,
+      average: humanize,
       trimMantissa: true,
-      mantissa: round ? 0 : 3,
+      mantissa: round ? 0 : 2,
     })
 }

--- a/src/helpers/numberFormat.ts
+++ b/src/helpers/numberFormat.ts
@@ -1,5 +1,10 @@
-import { numeral } from '../i18n'
+import { numbro } from '../i18n'
 
 export function numberFormatter(humanize: boolean, round: boolean) {
-  return (value: number) => numeral(value).format(`0${!round ? '.[000]' : ''}${humanize ? 'a' : ''}`)
+  return (value: number) =>
+    numbro(value).format({
+      average: humanize || undefined,
+      trimMantissa: true,
+      mantissa: round ? 0 : 3,
+    })
 }

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -2,11 +2,13 @@ import i18n from 'i18next'
 import { initReactI18next } from 'react-i18next'
 import LanguageDetector from 'i18next-browser-languagedetector'
 
-import numeral from 'numeral'
 import resources from './locales'
 import { getCurrentLang } from './components/LanguageSwitcher'
 
-import langs from './langs'
+import SupportedLocales, { SupportedLocale } from './langs'
+
+import numbro from 'numbro'
+Object.values(require('numbro/dist/languages.min.js')).forEach((l: any) => numbro.registerLanguage(l))
 
 const lang = getCurrentLang()
 
@@ -32,12 +34,12 @@ i18n
     },
   })
 
-i18n.on('languageChanged', (lang) => {
-  numeral.locale(langs[lang].numeralLocale)
+i18n.on('languageChanged', (lang: SupportedLocale) => {
+  numbro.setLanguage(SupportedLocales[lang].numbroLocale)
 })
 
-numeral.locale(langs[lang].numeralLocale)
+numbro.setLanguage(SupportedLocales[lang].numbroLocale)
 
-export { numeral }
+export { numbro }
 
 export default i18n

--- a/src/langs.ts
+++ b/src/langs.ts
@@ -1,40 +1,38 @@
 /* eslint-disable only-ascii/only-ascii */
-export type Lang = {
-  lang: string
-  numeralLocale: string
-  name: string
-}
-
-const langs: { [key: string]: Lang } = {
+const SupportedLocales = {
   en: {
     lang: 'en',
-    numeralLocale: 'en-gb',
+    numbroLocale: 'en-US',
     name: 'english',
   },
   fr: {
     lang: 'fr',
-    numeralLocale: 'fr-ca',
+    numbroLocale: 'fr-FR',
     name: 'français',
   },
   pt: {
     lang: 'pt',
-    numeralLocale: 'pt-br',
+    numbroLocale: 'pt-PT',
     name: 'português',
   },
   de: {
     lang: 'de',
-    numeralLocale: 'de',
+    numbroLocale: 'de-DE',
     name: 'deutsch',
   },
   es: {
     lang: 'es',
-    numeralLocale: 'es',
+    numbroLocale: 'es-ES',
     name: 'español',
   },
   pl: {
     lang: 'pl',
+    numbroLocale: 'pl-PL',
     name: 'polski',
   },
-}
+} as const
 
-export default langs
+export type SupportedLocale = keyof typeof SupportedLocales
+export type Locale = typeof SupportedLocales[keyof typeof SupportedLocales]
+
+export default SupportedLocales

--- a/src/locales/de/index.ts
+++ b/src/locales/de/index.ts
@@ -1,4 +1,3 @@
 import * as translation from './translation.json'
-import 'numeral/locales/de'
 
 export default { translation }

--- a/src/locales/en/index.ts
+++ b/src/locales/en/index.ts
@@ -1,5 +1,4 @@
 import * as translation from './translation.json'
 import * as localized from '../localized/localized.json'
-import 'numeral/locales/en-gb'
 
 export default { localized, translation }

--- a/src/locales/es/index.ts
+++ b/src/locales/es/index.ts
@@ -1,4 +1,3 @@
 import * as translation from './translation.json'
-import 'numeral/locales/es'
 
 export default { translation }

--- a/src/locales/fr/index.ts
+++ b/src/locales/fr/index.ts
@@ -1,4 +1,3 @@
 import * as translation from './translation.json'
-import 'numeral/locales/fr-ca'
 
 export default { translation }

--- a/src/locales/pt/index.ts
+++ b/src/locales/pt/index.ts
@@ -1,4 +1,3 @@
 import * as translation from './translation.json'
-import 'numeral/locales/pt-br'
 
 export default { translation }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3584,6 +3584,11 @@ big.js@^5.2.2:
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
   integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
 
+bignumber.js@^8.1.1:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-8.1.1.tgz#4b072ae5aea9c20f6730e4e5d529df1271c4d885"
+  integrity sha512-QD46ppGintwPGuL1KqmwhR0O+N2cZUg8JG/VzwI2e28sM9TqHjQB10lI4QAaMHVbLzwVLLAwEglpKPViWX+5NQ==
+
 binary-extensions@^1.0.0:
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.13.1.tgz#598afe54755b2868a5330d2aff9d4ebb53209b65"
@@ -10752,10 +10757,12 @@ number-is-nan@^1.0.0:
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
   integrity sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
 
-numeral@2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/numeral/-/numeral-2.0.6.tgz#4ad080936d443c2561aed9f2197efffe25f4e506"
-  integrity sha1-StCAk21EPCVhrtnyGX7//iX05QY=
+numbro@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/numbro/-/numbro-2.2.0.tgz#6e40e21e0eff55553d45a0d0fd4f7bf6cd2ab1ea"
+  integrity sha512-qgIU8Zfz2A7Nu9ILL0jV1hfriG5v1G8+b19zyrQNK8spUmJaHcn1YYXzNDRrb7IXBlTrW61ZUsKT/bCijeEGiQ==
+  dependencies:
+    bignumber.js "^8.1.1"
 
 nwsapi@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
## Related issues and PRs
Fixes #158 

## Description
Replace numeral, with numbro, which has more i18n support

![Screenshot of Polish abbreviated values](https://user-images.githubusercontent.com/2041260/78100578-012b6380-739a-11ea-939b-2946e07553ac.png)

## Impacted Areas in the application
Rendering of numbers on results charts, tables.

## Testing
Switch language to Polish, observe that numbers are abbreviated with locale appropriate abbreviations.
