### PR TITLE
Feat/solve ode until

### DIFF
--- a/src/algorithms/model.test.ts
+++ b/src/algorithms/model.test.ts
@@ -108,11 +108,9 @@ describe('model', () => {
         initializePopulationInput.ages,
       )
 
-      const result = [...new Array(5)].reduce((acc) => {
-        return evolve(acc, params, identity)
-      }, input)
-
-      // evolveOutput5 is the output after the 5th iteration with default parameters
+      // run model for 0.25 days
+      const result = evolve(input, params, input.time + 0.25, identity)
+      // compare result with snapshot
       expect(result).toMatchSnapshot()
     })
   })

--- a/src/algorithms/model.ts
+++ b/src/algorithms/model.ts
@@ -44,7 +44,6 @@ export function getPopulationParams(
   ageCounts: Record<string, number>,
   containment: (t: Date) => number,
 ): ModelParams {
-  const timeDeltaDays = eulerStep
 
   // TODO: Make this a form-adjustable factor
   const pop: ModelParams = {
@@ -68,8 +67,6 @@ export function getPopulationParams(
     },
     importsPerDay: { total: params.importsPerDay },
 
-    timeDeltaDays,
-    timeDelta: msPerDay * timeDeltaDays,
     populationServed: params.populationServed,
     numberStochasticRuns: params.numberStochasticRuns,
     hospitalBeds: params.hospitalBeds,

--- a/src/algorithms/model.ts
+++ b/src/algorithms/model.ts
@@ -232,14 +232,25 @@ interface StateFlux {
   }
 }
 
+export function evolve(pop: SimulationTimePoint, P: ModelParams, tMax: number, sample: (x: number) => number): SimulationTimePoint {
+  const dT: number = tMax - pop.time
+  const nSteps: number = Math.max(1, Math.round(dT / eulerStep))
+  const dt = dT / nSteps
+  let currState = pop
+  for (let i = 0; i < nSteps; i++) {
+    currState = stepODE(currState, P, dt, sample)
+  }
+  return currState
+}
+
 // NOTE: Assumes all subfields corresponding to populations have the same set of keys
-export function evolve(pop: SimulationTimePoint, P: ModelParams, sample: (x: number) => number): SimulationTimePoint {
+export function stepODE(pop: SimulationTimePoint, P: ModelParams, dt: number, sample: (x: number) => number): SimulationTimePoint {
   const sum = (dict: Record<string, number>): number => {
     return Object.values(dict).reduce((a, b) => a + b, 0)
   }
   const fracInfected = sum(pop.current.infectious) / P.populationServed
 
-  const newTime = new Date(pop.time + P.timeDelta)
+  const newTime = new Date(pop.time + dt * msPerDay)
   const newPop: SimulationTimePoint = {
     time: newTime.valueOf(),
     current: {
@@ -304,58 +315,58 @@ export function evolve(pop: SimulationTimePoint, P: ModelParams, sample: (x: num
 
     // Susceptible -> Exposed
     flux.susceptible[age] =
-      sample(P.importsPerDay[age] * P.timeDeltaDays) +
+      sample(P.importsPerDay[age] * dt) +
       sample(
         (1 - P.frac.isolated[age]) *
           P.rate.infection(newTime) *
           pop.current.susceptible[age] *
           fracInfected *
-          P.timeDeltaDays,
+          dt,
       )
 
     // Exposed -> Internal -> Infectious
     pop.current.exposed[age].forEach((exposed, i, exposedArray) => {
       flux.exposed[age][i] = Math.min(
         exposed,
-        sample(P.rate.latency * (exposed * P.timeDeltaDays) * exposedArray.length),
+        sample(P.rate.latency * (exposed * dt) * exposedArray.length),
       )
     })
 
     // Infectious -> Recovered/Critical
     flux.infectious.recovered[age] = Math.min(
       pop.current.infectious[age],
-      sample(pop.current.infectious[age] * P.timeDeltaDays * P.rate.recovery[age]),
+      sample(pop.current.infectious[age] * dt * P.rate.recovery[age]),
     )
     flux.infectious.severe[age] = Math.min(
       pop.current.infectious[age] - flux.infectious.recovered[age],
-      sample(pop.current.infectious[age] * P.timeDeltaDays * P.rate.severe[age]),
+      sample(pop.current.infectious[age] * dt * P.rate.severe[age]),
     )
     // Severe -> Recovered/Critical
     flux.severe.recovered[age] = Math.min(
       pop.current.severe[age],
-      sample(pop.current.severe[age] * P.timeDeltaDays * P.rate.discharge[age]),
+      sample(pop.current.severe[age] * dt * P.rate.discharge[age]),
     )
     flux.severe.critical[age] = Math.min(
       pop.current.severe[age] - flux.severe.recovered[age],
-      sample(pop.current.severe[age] * P.timeDeltaDays * P.rate.critical[age]),
+      sample(pop.current.severe[age] * dt * P.rate.critical[age]),
     )
     // Critical -> Severe/Fatality
     flux.critical.severe[age] = Math.min(
       pop.current.critical[age],
-      sample(pop.current.critical[age] * P.timeDeltaDays * P.rate.stabilize[age]),
+      sample(pop.current.critical[age] * dt * P.rate.stabilize[age]),
     )
     flux.critical.fatality[age] = Math.min(
       pop.current.critical[age] - flux.critical.severe[age],
-      sample(pop.current.critical[age] * P.timeDeltaDays * P.rate.fatality[age]),
+      sample(pop.current.critical[age] * dt * P.rate.fatality[age]),
     )
     // Overflow -> Severe/Fatality
     flux.overflow.severe[age] = Math.min(
       pop.current.overflow[age],
-      sample(pop.current.overflow[age] * P.timeDeltaDays * P.rate.stabilize[age]),
+      sample(pop.current.overflow[age] * dt * P.rate.stabilize[age]),
     )
     flux.overflow.fatality[age] = Math.min(
       pop.current.overflow[age] - flux.overflow.severe[age],
-      sample(pop.current.overflow[age] * P.timeDeltaDays * P.rate.overflowFatality[age]),
+      sample(pop.current.overflow[age] * dt * P.rate.overflowFatality[age]),
     )
 
     update('susceptible', age, -flux.susceptible[age])

--- a/src/algorithms/model.ts
+++ b/src/algorithms/model.ts
@@ -229,7 +229,12 @@ interface StateFlux {
   }
 }
 
-export function evolve(pop: SimulationTimePoint, P: ModelParams, tMax: number, sample: (x: number) => number): SimulationTimePoint {
+export function evolve(
+  pop: SimulationTimePoint,
+  P: ModelParams,
+  tMax: number,
+  sample: (x: number) => number,
+): SimulationTimePoint {
   const dT: number = tMax - pop.time
   const nSteps: number = Math.max(1, Math.round(dT / eulerStep))
   const dt = dT / nSteps
@@ -241,7 +246,12 @@ export function evolve(pop: SimulationTimePoint, P: ModelParams, tMax: number, s
 }
 
 // NOTE: Assumes all subfields corresponding to populations have the same set of keys
-export function stepODE(pop: SimulationTimePoint, P: ModelParams, dt: number, sample: (x: number) => number): SimulationTimePoint {
+export function stepODE(
+  pop: SimulationTimePoint,
+  P: ModelParams,
+  dt: number,
+  sample: (x: number) => number,
+): SimulationTimePoint {
   const sum = (dict: Record<string, number>): number => {
     return Object.values(dict).reduce((a, b) => a + b, 0)
   }

--- a/src/algorithms/run.ts
+++ b/src/algorithms/run.ts
@@ -112,21 +112,17 @@ export default async function run(
   containment: TimeSeries,
 ): Promise<AlgorithmResult> {
   const modelParams = getPopulationParams(params, severity, ageDistribution, interpolateTimeSeries(containment))
-  const tMin: number = params.simulationTimeRange.tMin.getTime()
-  const tMax: number = params.simulationTimeRange.tMax.getTime()
+  const tMin: number = new Date(params.simulationTimeRange.tMin).getTime()
+  const tMax: number = new Date(params.simulationTimeRange.tMax).getTime()
   const initialCases = params.suspectedCasesToday
   let initialState = initializePopulation(modelParams.populationServed, initialCases, tMin, ageDistribution)
 
   function simulate(initialState: SimulationTimePoint, func: (x: number) => number) {
     const dynamics = [initialState]
     let currState = initialState
-    let i = 0
     while (currState.time < tMax) {
-      currState = evolve(currState, modelParams, func)
-      i++
-      if (i % eulerStepsPerDay == 0) {
-        dynamics.push(currState)
-      }
+      currState = evolve(currState, modelParams, currState.time + 1, func)
+      dynamics.push(currState)
     }
 
     return collectTotals(dynamics)

--- a/src/algorithms/run.ts
+++ b/src/algorithms/run.ts
@@ -4,7 +4,7 @@ import { OneCountryAgeDistribution } from '../assets/data/CountryAgeDistribution
 
 import { SeverityTableRow } from '../components/Main/Scenario/SeverityTable'
 
-import { collectTotals, evolve, eulerStepsPerDay, getPopulationParams, initializePopulation } from './model'
+import { collectTotals, evolve, getPopulationParams, initializePopulation } from './model'
 import { AllParamsFlat } from './types/Param.types'
 import { AlgorithmResult, SimulationTimePoint } from './types/Result.types'
 import { TimeSeries } from './types/TimeSeries.types'


### PR DESCRIPTION
## Related issues and PRs
#313 

## Description
this PR separates the logic of stepping the ODE forward from integrating to a specified time. This will facilitate transitioning to a higher order integration scheme and should make tests more robust.

## Impacted Areas in the application
the model, specifically `run.ts` and `model.ts`

## Testing
tests might break because new snapshots are needed. 
