### PR TITLE
add an age distribution / population column to the severity table

### DIFF
--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -60,7 +60,7 @@ async function runSimulation(
     return
   }
 
-  if (params.population.cases !== "none" && !isRegion(params.population.cases)) {
+  if (params.population.cases !== 'none' && !isRegion(params.population.cases)) {
     console.error(`The given confirmed cases region is invalid: ${params.population.cases}`)
     return
   }
@@ -77,8 +77,6 @@ async function runSimulation(
   caseCounts.sort((a, b) => (a.time > b.time ? 1 : -1))
   setEmpiricalCases(caseCounts)
 }
-
-const severityDefaults: SeverityTableRow[] = updateSeverityTable(severityData)
 
 const isCountry = (country: string): country is keyof CountryAgeDistribution => {
   return Object.prototype.hasOwnProperty.call(countryAgeDistributionData, country)
@@ -97,10 +95,21 @@ function Main() {
     deserializeScenarioFromURL,
   )
 
-  // TODO: Can this complex state be handled by formik too?
-  const [severity, setSeverity] = useState<SeverityTableRow[]>(severityDefaults)
+  const [severity, setSeverity] = useState<SeverityTableRow[]>([])
 
   const [empiricalCases, setEmpiricalCases] = useState<EmpiricalData | undefined>()
+
+  useEffect(() => {
+    const ageDistribution = (countryAgeDistributionData as CountryAgeDistribution)[
+      scenarioState.data.population.country
+    ]
+
+    const severityDataWithAgeDistribution = severityData.map((ageRow) => {
+      return { ...ageRow, population: ageDistribution[ageRow.ageGroup] }
+    })
+
+    setSeverity(updateSeverityTable(severityDataWithAgeDistribution))
+  }, [scenarioState.data.population.country])
 
   const togglePersistAutorun = () => {
     LocalStorage.set(LOCAL_STORAGE_KEYS.AUTORUN_SIMULATION, !autorunSimulation)

--- a/src/components/Main/Scenario/SeverityTable.tsx
+++ b/src/components/Main/Scenario/SeverityTable.tsx
@@ -1,23 +1,17 @@
 import React from 'react'
-
 import _ from 'lodash'
-
 import i18next from 'i18next'
-
 import { Col, Row } from 'reactstrap'
-
 import { ChangeSet, Column, EditingState, Row as TableRow, Table as TableBase } from '@devexpress/dx-react-grid'
-
 import { Grid, Table, TableHeaderRow, TableInlineCellEditing } from '@devexpress/dx-react-grid-bootstrap4'
-
 import { format as d3format } from 'd3-format'
 
 import { updateSeverityTable } from './severityTableUpdate'
-
 import './SeverityTable.scss'
 
 const columns: SeverityTableColumn[] = [
   { name: 'ageGroup', title: i18next.t('Age group') },
+  { name: 'population', title: i18next.t('Age distribution') },
   { name: 'confirmed', title: `${i18next.t('Confirmed')}\n% ${i18next.t('total')}` },
   { name: 'severe', title: `${i18next.t('Severe')}\n% ${i18next.t('of confirmed')}` },
   { name: 'critical', title: `${i18next.t('Critical')}\n% ${i18next.t('of severe')}` },
@@ -91,6 +85,10 @@ export function EditableCell({
           onFocus={onFocus}
           onKeyDown={onKeyDown}
           readOnly={isReadOnly}
+          role="spinbutton"
+          aria-valuemin={0}
+          aria-valuemax={1000}
+          aria-valuenow={value}
         />
       </div>
     </td>
@@ -126,6 +124,7 @@ export function Cell({ value, children, column, row, tableColumn, tableRow, onCl
 export interface SeverityTableRow {
   id: number
   ageGroup: string
+  population: number
   confirmed: number
   severe: number
   critical: number

--- a/src/components/Main/Scenario/severityTableUpdate.ts
+++ b/src/components/Main/Scenario/severityTableUpdate.ts
@@ -1,4 +1,4 @@
-import { SeverityTableRow } from './SeverityTable'
+import type { SeverityTableRow } from './SeverityTable'
 
 import { validatePercentage } from './validatePercentage'
 


### PR DESCRIPTION
## Related issues and PRs

Contributes to #332

## Description

Creates the column. Does not send it to run() or any of the other requirements. 

## Impacted Areas in the application

Severity table

## Testing

Initial values as expected, changes as scenarios change.