### PR TITLE
#362 quick fix for URL state tracking

### DIFF
--- a/src/components/Main/state/URLSerializer.ts
+++ b/src/components/Main/state/URLSerializer.ts
@@ -48,12 +48,18 @@ export function deserializeScenarioFromURL(initState: State): State {
         ...initState,
         current: obj.current,
         data: {
-          population: initState.data.population,
+          population: {
+            ...initState.data.population,
+            ...obj.population,
+          },
           containment: {
             reduction: containmentDataReduction,
             numberPoints: containmentDataReduction.length,
           },
-          epidemiological: initState.data.epidemiological,
+          epidemiological: {
+            ...initState.data.epidemiological,
+            ...obj.epidemiological,
+          },
           simulation: obj.simulation,
         },
       }


### PR DESCRIPTION
## Related issues and PRs

Fixes #362, Related to #326 #338. Ignores #370.

## Description

Management of app state in browser URL was broken by #236. This change simply restores prior behavior and does not attempt to imagine a better way to manage and share app state. See #326 #338 et al for that.

Note: The scenario select does not display "Custom" on reload. That could be addressed as a new issue.

## Impacted Areas in the application

App state in the URL.

## Testing

Go to the app. Change some parameters. Reload. The parameters are as changed.
