### PR TITLE
fix: (370) Query string doesn't persist through landing page

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -13,11 +13,13 @@ import { State } from '../state/reducer'
 
 function App() {
   const shouldGoToLandingPage = useSelector(({ ui }: State) => !ui.skipLandingPage)
+  const initialQueryString = window.location.search
+
   return (
     <Switch>
       {shouldGoToLandingPage && <Redirect exact from="/" to="/start" />}
       <Route exact path="/start">
-        <LandingPage />
+        <LandingPage initialQueryString={initialQueryString} />
       </Route>
       <Route>
         <Layout />

--- a/src/components/LandingPage/LandingPage.tsx
+++ b/src/components/LandingPage/LandingPage.tsx
@@ -10,11 +10,16 @@ import './LandingPage.scss'
 
 import { useTranslation } from 'react-i18next'
 
-function LandingPage() {
+interface LandingPageProps {
+  initialQueryString: string
+}
+
+function LandingPage({ initialQueryString }: LandingPageProps) {
   const { t } = useTranslation()
   const [isSkipLandingChecked, setSkipLandingChecked] = useState(false)
   const showSkipCheckbox = useSelector(({ ui }: State) => !ui.skipLandingPage)
   const dispatch = useDispatch()
+  const redirectUrl = `/${initialQueryString || ''}`
   const onLinkClick = useCallback(() => {
     dispatch(setShouldSkipLandingPage({ shouldSkip: true }))
 
@@ -34,7 +39,7 @@ function LandingPage() {
           <h1 className="landing-page__heading">{t('COVID-19 Scenarios')}</h1>
           <p className="landing-page__sub-heading">{t('Tool that models COVID-19 outbreak and hospital demand')}</p>
         </div>
-        <Link onClick={onLinkClick} to="/" className="landing-page__simulate-link">
+        <Link onClick={onLinkClick} to={redirectUrl} className="landing-page__simulate-link">
           {t('Simulate')}
         </Link>
       </div>


### PR DESCRIPTION
## Related issues and PRs
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->
 - https://github.com/neherlab/covid19_scenarios/issues/370

## Description
<!-- Goal of the pull request -->
Query string now survives the landing page, so links shared via email will work, meaning the data from the URL will deserialize properly into a scenario.

There are a couple of PRs depending on this functionality:

https://github.com/neherlab/covid19_scenarios/pull/368, https://github.com/neherlab/covid19_scenarios/pull/366, https://github.com/neherlab/covid19_scenarios/pull/329

![landing-page-query-string](https://user-images.githubusercontent.com/1078403/78304120-e988e200-7535-11ea-97fc-dee537e733fd.gif)

