### PR TITLE
Custom age distributions II

### DIFF
--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -15,8 +15,6 @@ import { run, intervalsToTimeSeries } from '../../algorithms/run'
 
 import LocalStorage, { LOCAL_STORAGE_KEYS } from '../../helpers/localStorage'
 
-import { CountryAgeDistribution } from '../../assets/data/CountryAgeDistribution.types'
-import countryAgeDistributionData from '../../assets/data/country_age_distribution.json'
 import severityData from '../../assets/data/severityData.json'
 
 import countryCaseCountData from '../../assets/data/case_counts.json'
@@ -58,33 +56,22 @@ async function runSimulation(
     ...params.containment,
   }
 
-  if (!isCountry(params.population.country)) {
-    console.error(`The given country is invalid: ${params.population.country}`)
-    return
-  }
-
   if (params.population.cases !== 'none' && !isRegion(params.population.cases)) {
     console.error(`The given confirmed cases region is invalid: ${params.population.cases}`)
     return
   }
 
-  const ageDistribution = (countryAgeDistributionData as CountryAgeDistribution)[params.population.country]
   const caseCounts: EmpiricalData = countryCaseCountData[params.population.cases] || []
   const containment: TimeSeries = intervalsToTimeSeries(params.containment.mitigationIntervals)
 
   intervalsToTimeSeries(params.containment.mitigationIntervals)
-  const newResult = await run(paramsFlat, severity, ageDistribution, containment)
-
+  const newResult = await run(paramsFlat, severity, scenarioState.ageDistribution, containment)
   setResult(newResult)
   caseCounts.sort((a, b) => (a.time > b.time ? 1 : -1))
   setEmpiricalCases(caseCounts)
 }
 
 const severityDefaults: SeverityTableRow[] = updateSeverityTable(severityData)
-
-const isCountry = (country: string): country is keyof CountryAgeDistribution => {
-  return Object.prototype.hasOwnProperty.call(countryAgeDistributionData, country)
-}
 
 const isRegion = (region: string): region is keyof typeof countryCaseCountData => {
   return Object.prototype.hasOwnProperty.call(countryCaseCountData, region)

--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -31,9 +31,9 @@ import { serialize } from './state/serialization/StateSerializer'
 import { ResultsCard } from './Results/ResultsCard'
 import { ScenarioCard } from './Scenario/ScenarioCard'
 import { updateSeverityTable } from './Scenario/severityTableUpdate'
+import { TimeSeries } from '../../algorithms/types/TimeSeries.types'
 
 import './Main.scss'
-import { TimeSeries } from '../../algorithms/types/TimeSeries.types'
 
 export function severityTableIsValid(severity: SeverityTableRow[]) {
   return !severity.some((row) => _.values(row?.errors).some((x) => x !== undefined))
@@ -45,6 +45,7 @@ export function severityErrors(severity: SeverityTableRow[]) {
 
 async function runSimulation(
   params: AllParams,
+  scenarioState: State,
   severity: SeverityTableRow[],
   setResult: React.Dispatch<React.SetStateAction<AlgorithmResult | undefined>>,
   setEmpiricalCases: React.Dispatch<React.SetStateAction<EmpiricalData | undefined>>,
@@ -117,12 +118,13 @@ function Main() {
     // if the link contains query, we're executing the scenario (and displaying graphs)
     // this is because the page was either shared via link, or opened in new tab
     if (window.location.search) {
-      debouncedRun(allParams, severity)
+      debouncedRun(allParams, scenarioState, severity)
     }
   }, [])
 
   const [debouncedRun] = useDebouncedCallback(
-    (params: AllParams, severity: SeverityTableRow[]) => runSimulation(params, severity, setResult, setEmpiricalCases),
+    (params: AllParams, scenarioState: State, severity: SeverityTableRow[]) =>
+      runSimulation(params, scenarioState, severity, setResult, setEmpiricalCases),
     500,
   )
 
@@ -139,7 +141,7 @@ function Main() {
 
     if (autorunSimulation) {
       updateBrowserUrl()
-      debouncedRun(allParams, severity)
+      debouncedRun(allParams, scenarioState, severity)
     }
   }, [autorunSimulation, debouncedRun, scenarioState, scenarioQueryString, severity])
 
@@ -165,7 +167,7 @@ function Main() {
 
   function handleSubmit(params: AllParams, { setSubmitting }: FormikHelpers<AllParams>) {
     updateBrowserUrl()
-    runSimulation(params, severity, setResult, setEmpiricalCases)
+    runSimulation(params, scenarioState, severity, setResult, setEmpiricalCases)
     setSubmitting(false)
   }
 

--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -24,7 +24,7 @@ import { schema } from './validation/schema'
 import { setContainmentData, setPopulationData, setEpidemiologicalData, setSimulationData } from './state/actions'
 import { scenarioReducer } from './state/reducer'
 
-import { defaultScenarioState } from './state/state'
+import { defaultScenarioState, State } from './state/state'
 import { deserializeScenarioFromURL } from './state/serialization/URLSerializer'
 import { serialize } from './state/serialization/StateSerializer'
 

--- a/src/components/Main/Scenario/ScenarioCard.tsx
+++ b/src/components/Main/Scenario/ScenarioCard.tsx
@@ -80,7 +80,12 @@ function ScenarioCard({ severity, scenarioState, errors, touched, setSeverity, s
 
         <Row noGutters>
           <Col className="my-2">
-            <SeverityCard severity={severity} setSeverity={setSeverity} />
+            <SeverityCard
+              severity={severity}
+              setSeverity={setSeverity}
+              scenarioState={scenarioState}
+              scenarioDispatch={scenarioDispatch}
+            />
           </Col>
         </Row>
       </>

--- a/src/components/Main/Scenario/ScenarioCardPopulation.tsx
+++ b/src/components/Main/Scenario/ScenarioCardPopulation.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import i18next from 'i18next'
 
 import { FormikErrors, FormikTouched } from 'formik'
 import { AnyAction } from 'typescript-fsa'
@@ -7,18 +8,16 @@ import { useTranslation } from 'react-i18next'
 
 import countryAgeDistribution from '../../../assets/data/country_age_distribution.json'
 import countryCaseCounts from '../../../assets/data/case_counts.json'
+import { State, CUSTOMIZED_AGE_DISTRIBUTION } from '../state/state'
 
 import { CardWithoutDropdown } from '../../Form/CardWithoutDropdown'
 import { FormDatePicker } from '../../Form/FormDatePicker'
 import { FormDropdown } from '../../Form/FormDropdown'
 import { FormSpinBox } from '../../Form/FormSpinBox'
 
-// import { setPopulationScenario } from '../state/actions'
-
-import { State } from '../state/state'
-
 const countries = Object.keys(countryAgeDistribution)
 const countryOptions = countries.map((country) => ({ value: country, label: country }))
+countryOptions.push({ value: CUSTOMIZED_AGE_DISTRIBUTION, label: i18next.t(CUSTOMIZED_AGE_DISTRIBUTION) })
 const caseCountOptions = Object.keys(countryCaseCounts).map((country) => ({ value: country, label: country }))
 caseCountOptions.push({ value: 'none', label: 'None' })
 

--- a/src/components/Main/Scenario/ScenarioCardPopulation.tsx
+++ b/src/components/Main/Scenario/ScenarioCardPopulation.tsx
@@ -8,7 +8,7 @@ import { useTranslation } from 'react-i18next'
 
 import countryAgeDistribution from '../../../assets/data/country_age_distribution.json'
 import countryCaseCounts from '../../../assets/data/case_counts.json'
-import { State, CUSTOMIZED_AGE_DISTRIBUTION } from '../state/state'
+import { State, CUSTOM_COUNTRY_NAME } from '../state/state'
 
 import { CardWithoutDropdown } from '../../Form/CardWithoutDropdown'
 import { FormDatePicker } from '../../Form/FormDatePicker'
@@ -17,7 +17,7 @@ import { FormSpinBox } from '../../Form/FormSpinBox'
 
 const countries = Object.keys(countryAgeDistribution)
 const countryOptions = countries.map((country) => ({ value: country, label: country }))
-countryOptions.push({ value: CUSTOMIZED_AGE_DISTRIBUTION, label: i18next.t(CUSTOMIZED_AGE_DISTRIBUTION) })
+countryOptions.push({ value: CUSTOM_COUNTRY_NAME, label: i18next.t(CUSTOM_COUNTRY_NAME) })
 const caseCountOptions = Object.keys(countryCaseCounts).map((country) => ({ value: country, label: country }))
 caseCountOptions.push({ value: 'none', label: 'None' })
 

--- a/src/components/Main/Scenario/SeverityCard.tsx
+++ b/src/components/Main/Scenario/SeverityCard.tsx
@@ -1,17 +1,19 @@
 import React from 'react'
-
 import { useTranslation } from 'react-i18next'
+import { AnyAction } from 'typescript-fsa'
 
 import { CollapsibleCard } from '../../Form/CollapsibleCard'
-
 import { SeverityTable, SeverityTableRow } from './SeverityTable'
+import { State } from '../state/state'
 
 export interface SeverityCardProps {
   severity: SeverityTableRow[]
   setSeverity(severity: SeverityTableRow[]): void
+  scenarioState: State
+  scenarioDispatch(action: AnyAction): void
 }
 
-function SeverityCard({ severity, setSeverity }: SeverityCardProps) {
+function SeverityCard({ severity, setSeverity, scenarioState, scenarioDispatch }: SeverityCardProps) {
   const { t } = useTranslation()
   return (
     <CollapsibleCard
@@ -33,7 +35,12 @@ function SeverityCard({ severity, setSeverity }: SeverityCardProps) {
         )}
       </p>
 
-      <SeverityTable severity={severity} setSeverity={setSeverity} />
+      <SeverityTable
+        severity={severity}
+        setSeverity={setSeverity}
+        scenarioState={scenarioState}
+        scenarioDispatch={scenarioDispatch}
+      />
     </CollapsibleCard>
   )
 }

--- a/src/components/Main/Scenario/SeverityCard.tsx
+++ b/src/components/Main/Scenario/SeverityCard.tsx
@@ -20,27 +20,36 @@ function SeverityCard({ severity, setSeverity, scenarioState, scenarioDispatch }
       identifier="severity-card"
       title={
         <>
-          <h3 className="my-1 text-wrap">{t('Severity assumptions and age-specific isolation')}</h3>
+          <h3 className="my-1 text-wrap">{t('Age group specific parameters')}</h3>
           <p className="my-0">
-            {t('based on data from')} {t('China')}
+            {t('Demographics')} -- {t('Disease severity')} -- {t('Group specific isolation')}
           </p>
         </>
       }
       help={t('Assumptions on severity which are informed by epidemiological and clinical observations in China')}
       defaultCollapsed
     >
-      <p>
-        {t(
-          'This table summarizes the assumptions on severity which are informed by epidemiological and clinical observations in China. The first column reflects our assumption on what fraction of infections are reflected in the statistics from China, the following columns contain the assumption on what fraction of the previous category deteriorates to the next. These fields are editable and can be adjusted to different assumptions. The last column is the implied infection fatality for different age groups.',
-        )}
-      </p>
-
       <SeverityTable
         severity={severity}
         setSeverity={setSeverity}
         scenarioState={scenarioState}
         scenarioDispatch={scenarioDispatch}
       />
+      <p>
+        {t('Summary of demographics and age dependent parameters.')} &nbsp;
+        {t('The second column shows how many people fall into each age group.')} &nbsp;
+        {t(
+          'The following columns summarize COVID19 severity informed by epidemiological and clinical observations from China. ',
+        )}
+        &nbsp;
+        {t(
+          'The column "Confirmed" reflects our assumption on what fraction of infections are reflected in the statistics, the following columns contain the assumption on what fraction of the previous category deteriorates to the next. ',
+        )}
+        &nbsp;
+        {t('Most fields are editable and can be adjusted to different assumptions.')} &nbsp;
+        {t('The last column can be used to specify age-group specific isolation measures.')}
+      </p>
+
     </CollapsibleCard>
   )
 }

--- a/src/components/Main/Scenario/SeverityCard.tsx
+++ b/src/components/Main/Scenario/SeverityCard.tsx
@@ -27,7 +27,7 @@ function SeverityCard({ severity, setSeverity, scenarioState, scenarioDispatch }
         </>
       }
       help={t('Assumptions on severity which are informed by epidemiological and clinical observations in China')}
-      defaultCollapsed
+      defaultCollapsed={false}
     >
       <SeverityTable
         severity={severity}

--- a/src/components/Main/Scenario/SeverityCard.tsx
+++ b/src/components/Main/Scenario/SeverityCard.tsx
@@ -27,7 +27,7 @@ function SeverityCard({ severity, setSeverity, scenarioState, scenarioDispatch }
         </>
       }
       help={t('Assumptions on severity which are informed by epidemiological and clinical observations in China')}
-      defaultCollapsed={false}
+      defaultCollapsed
     >
       <SeverityTable
         severity={severity}

--- a/src/components/Main/Scenario/SeverityCard.tsx
+++ b/src/components/Main/Scenario/SeverityCard.tsx
@@ -49,7 +49,6 @@ function SeverityCard({ severity, setSeverity, scenarioState, scenarioDispatch }
         {t('Most fields are editable and can be adjusted to different assumptions.')} &nbsp;
         {t('The last column can be used to specify age-group specific isolation measures.')}
       </p>
-
     </CollapsibleCard>
   )
 }

--- a/src/components/Main/Scenario/SeverityTable.scss
+++ b/src/components/Main/Scenario/SeverityTable.scss
@@ -1,40 +1,40 @@
-@import '../../../styles/variables';
-
-// HACK: find a way to override these styles without `!important`
-.dx-g-bs4-header-cell {
-  max-width: 30px !important;
-  padding: 0 !important;
-  text-align: center;
-  text-wrap: normal !important;
+.severity-table table {
+  // 700 = the point at which the titles break for english
+  // !important because react-grid assigns a width to the table element
+  min-width: 700px !important;
 }
 
-// HACK: find a way to override these styles without `!important`
-.dx-g-bs4-table-cell {
-  max-width: 30px !important;
-  padding: 0 !important;
-  text-align: center !important;
+.severity-table table td,
+.severity-table table th {
+  padding: 0;
 }
 
-.table {
-  //max-width: 30px !important;
-  min-width: 100px !important;
+.severity-table table td > input {
+  padding: 0;
+  // otherwise bootstrap makes it too large
+  height: auto;
 }
 
-.table-cell-editable {
-  width: 75%;
-  min-width: 50px;
-  max-width: unset !important;
-  border: 1px solid $gray-300;
-
-  &:focus {
-    border: 1px solid $info;
-  }
+.severity-table table td p {
+  margin: 0;
 }
 
-.table-cell-editable-input {
-  width: 75%;
-  min-width: 50px;
-  padding: auto 1px;
-  border: 1px solid $gray-300;
-  outline: none;
+.severity-table table colgroup col:nth-child(3) {
+  background-color: #fdbf6f55;
+}
+
+.severity-table table colgroup col:nth-child(4) {
+  background-color: #fb9a9955;
+}
+
+.severity-table table colgroup col:nth-child(5) {
+  background-color: #e31a1c55;
+}
+
+.severity-table table colgroup col:nth-child(6) {
+  background-color: #cab2d655;
+}
+
+.severity-table table colgroup col:nth-child(8) {
+  background-color: #a6cee355;
 }

--- a/src/components/Main/Scenario/SeverityTable.tsx
+++ b/src/components/Main/Scenario/SeverityTable.tsx
@@ -90,6 +90,10 @@ export function EditableCell({
           onFocus={onFocus}
           onKeyDown={onKeyDown}
           readOnly={isReadOnly}
+          role="spinbutton"
+          aria-valuemin={0}
+          aria-valuemax={100000000000}
+          aria-valuenow={value}
         />
       </div>
     </td>

--- a/src/components/Main/Scenario/SeverityTable.tsx
+++ b/src/components/Main/Scenario/SeverityTable.tsx
@@ -185,10 +185,12 @@ function SeverityTable({ severity, setSeverity, scenarioState, scenarioDispatch 
     }
 
     const ageDistribution: OneCountryAgeDistribution = { ...scenarioState.ageDistribution }
-    changedRows.forEach((row) => {
+    changedRows = changedRows.map((row) => {
       if (row.population) {
         ageDistribution[row.ageGroup] = parseInt(`${row.population}`, 10)
+        return { ...row, population: ageDistribution[row.ageGroup] }
       }
+      return row
     })
 
     scenarioDispatch(setAgeDistributionData({ data: ageDistribution }))

--- a/src/components/Main/Scenario/SeverityTable.tsx
+++ b/src/components/Main/Scenario/SeverityTable.tsx
@@ -1,12 +1,22 @@
-import React from 'react'
+import React, { useState } from 'react'
 import _ from 'lodash'
 import i18next from 'i18next'
 import { AnyAction } from 'typescript-fsa'
 import { Col, Row } from 'reactstrap'
-import { ChangeSet, Column, EditingState, Row as TableRow, Table as TableBase } from '@devexpress/dx-react-grid'
+import {
+  ChangeSet,
+  Column,
+  EditingState,
+  EditingColumnExtension,
+  Row as TableRow,
+  Table as TableBase,
+  DataTypeProvider,
+  DataTypeProviderProps,
+} from '@devexpress/dx-react-grid'
 import { Grid, Table, TableHeaderRow, TableInlineCellEditing } from '@devexpress/dx-react-grid-bootstrap4'
 import { format as d3format } from 'd3-format'
 
+import { validatePositiveInteger } from './validateInteger'
 import { updateSeverityTable } from './severityTableUpdate'
 import { OneCountryAgeDistribution } from '../../../assets/data/CountryAgeDistribution.types'
 import { setAgeDistributionData } from '../state/actions'
@@ -25,106 +35,43 @@ const columns: SeverityTableColumn[] = [
   { name: 'isolated', title: `${i18next.t('Isolated')}\n% ${i18next.t('total')}` },
 ]
 
-const readOnlyColumns = ['ageGroup', 'totalFatal']
+const columnExtensions: Table.ColumnExtension[] = [
+  { columnName: 'ageGroup', align: 'center' },
+  { columnName: 'population', align: 'center' },
+  { columnName: 'confirmed', align: 'center' },
+  { columnName: 'severe', align: 'center' },
+  { columnName: 'critical', align: 'center' },
+  { columnName: 'fatal', align: 'center' },
+  { columnName: 'totalFatal', align: 'center' },
+  { columnName: 'isolated', align: 'center' },
+]
 
-const columnColors = {
-  confirmed: '#fdbf6f55',
-  severe: '#fb9a9955',
-  critical: '#e31a1c55',
-  fatal: '#cab2d655',
-  isolated: '#a6cee355',
-}
-
+const editingColumnExtensions: EditingColumnExtension[] = [
+  { columnName: 'ageGroup', editingEnabled: false },
+  { columnName: 'totalFatal', editingEnabled: false },
+]
 const getRowId = (row: TableRow) => row.id
 
 export type HeaderCellProps = Partial<TableBase.DataCellProps> & TableHeaderRow.CellProps
 
-export function HeaderCell({ column, ...restProps }: HeaderCellProps) {
+export function HeaderCell({ column }: HeaderCellProps) {
   const { title } = column
   const content = title?.split('\n').map((line, i) => (
-    <p key={`line ${i}: ${line}`} className={`p-0 m-0 text-center text-truncate ${i !== 0 ? 'small' : ''}`}>
+    <p key={`line ${i}: ${line}`} className={`text-center text-bold ${i !== 0 ? 'small' : ''}`}>
       {line}
     </p>
   ))
 
-  return (
-    <td className="py-1 text-bold" colSpan={1} title={title}>
-      {content}
-    </td>
-  )
+  return <td title={title}>{content}</td>
 }
 
-export interface EditableCellProps extends TableInlineCellEditing.CellProps {
-  onClick?(): void
-}
+const DecimalFormatter: React.FC<DataTypeProvider.ValueFormatterProps> = ({ value }) => (
+  <span>{d3format('.2')(parseFloat(value))}</span>
+)
 
-export function EditableCell({
-  column,
-  value,
-  tableRow,
-  tableColumn,
-  editingEnabled,
-  onValueChange,
-  row,
-  autoFocus,
-  onBlur,
-  onFocus,
-  onKeyDown,
-  ...restProps
-}: EditableCellProps) {
-  const isReadOnly = readOnlyColumns.includes(column.name)
-  const color = _.get(columnColors, column.name)
-
-  return (
-    <td className="dx-g-bs4-table-cell text-nowrap" {...restProps}>
-      <div style={{ backgroundColor: color }} className="w-100 h-100">
-        <input
-          type="number"
-          className="table-cell-editable-input text-center"
-          // readOnly={!editingEnabled}
-          value={value}
-          onChange={(e) => onValueChange && onValueChange(e.target.value)}
-          // eslint-disable-next-line jsx-a11y/no-autofocus
-          autoFocus={autoFocus}
-          onBlur={onBlur}
-          onFocus={onFocus}
-          onKeyDown={onKeyDown}
-          readOnly={isReadOnly}
-          role="spinbutton"
-          aria-valuemin={0}
-          aria-valuemax={100000000000}
-          aria-valuenow={value}
-        />
-      </div>
-    </td>
-  )
-}
-
-export interface CellProps extends TableBase.DataCellProps {
-  onClick?(): void
-}
-
-export function Cell({ value, children, column, row, tableColumn, tableRow, onClick, ...restProps }: CellProps) {
-  const isReadOnly = readOnlyColumns.includes(column.name)
-  const color = _.get(columnColors, column.name)
-
-  // Computed values may sometimes have way too many decimal digits
-  // so we format them here in order to display something more reasonable
-  const computedColumns = ['totalFatal']
-  let formattedValue = value
-  if (computedColumns.includes(column.name)) {
-    formattedValue = d3format('.2')(parseFloat(value))
-  }
-
-  const editableClass = isReadOnly ? '' : 'table-cell-editable'
-  return (
-    <td className="dx-g-bs4-table-cell text-nowrap text-center" {...restProps} onClick={onClick}>
-      <div style={{ backgroundColor: color }} className="w-100 h-100">
-        <div className={`mx-auto align-center ${editableClass}`}>{children ?? formattedValue}</div>
-      </div>
-    </td>
-  )
-}
+const DecimalTypeProvider: React.FC<DataTypeProviderProps> = (props) => (
+  <DataTypeProvider formatterComponent={DecimalFormatter} {...props} />
+)
 
 export interface SeverityTableRow {
   id: number
@@ -154,13 +101,22 @@ export interface SeverityTableProps {
   scenarioDispatch(action: AnyAction): void
 }
 
+interface AgeDistributionErrors {
+  id: number
+  ageGroup: string
+  error: string
+}
+
 /**
  *
  * Editable table of severity
  *
  * Adopted from https://devexpress.github.io/devextreme-reactive/react/grid/docs/guides/editing#inline-cell-editing
  */
+
 function SeverityTable({ severity, setSeverity, scenarioState, scenarioDispatch }: SeverityTableProps) {
+  const [ageDistributionErrors, setAgeDistributionErrors] = useState<AgeDistributionErrors[]>([])
+
   const commitChanges = ({ added, changed, deleted }: ChangeSet) => {
     let changedRows: SeverityTableRow[] = []
 
@@ -185,14 +141,21 @@ function SeverityTable({ severity, setSeverity, scenarioState, scenarioDispatch 
     }
 
     const ageDistribution: OneCountryAgeDistribution = { ...scenarioState.ageDistribution }
+    const thisAgeDistributionErrors: AgeDistributionErrors[] = []
     changedRows = changedRows.map((row) => {
       if (row.population) {
-        ageDistribution[row.ageGroup] = parseInt(`${row.population}`, 10)
-        return { ...row, population: ageDistribution[row.ageGroup] }
+        const { value, error } = validatePositiveInteger(row.population)
+        if (error) {
+          thisAgeDistributionErrors.push({ id: row.id, ageGroup: row.ageGroup, error })
+          return row
+        }
+        ageDistribution[row.ageGroup] = value
+        return { ...row, population: value }
       }
       return row
     })
 
+    setAgeDistributionErrors(thisAgeDistributionErrors)
     scenarioDispatch(setAgeDistributionData({ data: ageDistribution }))
     setSeverity(updateSeverityTable(changedRows))
   }
@@ -203,14 +166,16 @@ function SeverityTable({ severity, setSeverity, scenarioState, scenarioDispatch 
 
   return (
     <>
-      <Row noGutters>
+      <Row noGutters className="severity-table">
         <Col>
           <Grid rows={severityWithAgeDistribution} columns={columns} getRowId={getRowId}>
-            <EditingState onCommitChanges={commitChanges} />
+            <EditingState onCommitChanges={commitChanges} columnExtensions={editingColumnExtensions} />
 
-            <Table cellComponent={Cell} />
+            <DecimalTypeProvider for={['totalFatal']} />
 
-            <TableInlineCellEditing startEditAction={'click'} selectTextOnEditStart cellComponent={EditableCell} />
+            <Table columnExtensions={columnExtensions} />
+
+            <TableInlineCellEditing startEditAction={'click'} selectTextOnEditStart />
 
             <TableHeaderRow cellComponent={HeaderCell} />
           </Grid>
@@ -232,16 +197,35 @@ function SeverityTable({ severity, setSeverity, scenarioState, scenarioDispatch 
               }
 
               return (
-                <div key={`row-${id}-${column}`} className="text-danger">
-                  {`Error in row "${ageGroup}", column "${column}": ${message}`}
-                </div>
+                <ValidationError key={`row-${id}-${column}`} column={column} ageGroup={ageGroup} message={message} />
               )
             })
           })}
+          {ageDistributionErrors.map(
+            ({ id, ageGroup, error }) =>
+              error && (
+                <ValidationError
+                  key={`row-${id}-age-distribution`}
+                  column="age distribution"
+                  ageGroup={ageGroup}
+                  message={error}
+                />
+              ),
+          )}
         </Col>
       </Row>
     </>
   )
+}
+
+interface ValidationErrorProps {
+  column: string
+  ageGroup: string
+  message: string
+}
+
+function ValidationError({ column, ageGroup, message }: ValidationErrorProps) {
+  return <div className="text-danger">{`Error in row "${ageGroup}", column "${column}": ${message}`}</div>
 }
 
 export { SeverityTable }

--- a/src/components/Main/Scenario/validateInteger.ts
+++ b/src/components/Main/Scenario/validateInteger.ts
@@ -9,7 +9,7 @@ export function validateInteger(
   value: any, // eslint-disable-line @typescript-eslint/no-explicit-any
   zeroOrPositive = false,
 ): { value: number; error?: string } {
-  let integerSchema = yup.number().typeError(i18next.t('This value should be a number')).required(i18next.t('Required'))
+  let integerSchema = yup.number().integer(i18next.t('This value should be a integer')).required(i18next.t('Required'))
 
   if (zeroOrPositive) {
     integerSchema = integerSchema.min(0, i18next.t('This value should be non-negative'))

--- a/src/components/Main/Scenario/validateInteger.ts
+++ b/src/components/Main/Scenario/validateInteger.ts
@@ -1,0 +1,37 @@
+import * as yup from 'yup'
+
+import i18next from 'i18next'
+/**
+ * Checks that a given value is a valid integer and if not, attempts
+ * to cast it as such.. If unsuccesful, returns a NaN and an error message.
+ */
+export function validateInteger(
+  value: any, // eslint-disable-line @typescript-eslint/no-explicit-any
+  zeroOrPositive = false,
+): { value: number; error?: string } {
+  let integerSchema = yup.number().typeError(i18next.t('This value should be a number')).required(i18next.t('Required'))
+
+  if (zeroOrPositive) {
+    integerSchema = integerSchema.min(0, i18next.t('This value should be non-negative'))
+  }
+
+  try {
+    const castedValue = integerSchema.validateSync(value)
+    return { value: castedValue, error: undefined }
+  } catch (valError) {
+    const validationError = valError as yup.ValidationError
+    try {
+      const castedValue = integerSchema.cast(value)
+      return { value: castedValue, error: validationError.message }
+    } catch (typeError) {
+      return { value: NaN, error: validationError.message }
+    }
+  }
+}
+
+export function validatePositiveInteger(
+  value: any, // eslint-disable-line @typescript-eslint/no-explicit-any
+  zeroOrPositive = false,
+): { value: number; error?: string } {
+  return validateInteger(value, true)
+}

--- a/src/components/Main/state/actions.ts
+++ b/src/components/Main/state/actions.ts
@@ -1,12 +1,12 @@
 import actionCreatorFactory from 'typescript-fsa'
 
 import {
-  ScenarioData,
   ContainmentData,
   EpidemiologicalData,
   SimulationData,
   PopulationData,
 } from '../../../algorithms/types/Param.types'
+import { OneCountryAgeDistribution } from '../../../assets/data/CountryAgeDistribution.types'
 
 const action = actionCreatorFactory('SCENARIO')
 
@@ -15,10 +15,6 @@ export interface SetScenarioParams {
 }
 
 export const setScenario = action<SetScenarioParams>('SET_SCENARIO')
-
-export interface SetScenarioDataParams {
-  data: ScenarioData
-}
 
 export interface SetPopulationDataParams {
   data: PopulationData
@@ -36,8 +32,12 @@ export interface SetSimulationDataParams {
   data: SimulationData
 }
 
-export const setScenarioData = action<SetScenarioDataParams>('SET_SCENARIO_DATA')
+export interface SetAgeDistributionDataParams {
+  data: OneCountryAgeDistribution
+}
+
 export const setPopulationData = action<SetPopulationDataParams>('SET_POPULATION_DATA')
 export const setEpidemiologicalData = action<SetEpidemiologicalDataParams>('SET_EPIDEMIOLOGICAL_DATA')
 export const setContainmentData = action<SetContainmentDataParams>('SET_CONTAINMENT_DATA')
 export const setSimulationData = action<SetSimulationDataParams>('SET_SIMULATION_DATA')
+export const setAgeDistributionData = action<SetAgeDistributionDataParams>('SET_AGE_DISTRIBUTION_DATA')

--- a/src/components/Main/state/data.ts
+++ b/src/components/Main/state/data.ts
@@ -6,6 +6,8 @@ import createColor from 'create-color'
 import scenarios from '../../../assets/data/scenarios/scenarios.json'
 
 import { MitigationIntervals, ScenarioData } from '../../../algorithms/types/Param.types'
+import countryAgeDistributionData from '../../../assets/data/country_age_distribution.json'
+import { OneCountryAgeDistribution, CountryAgeDistribution } from '../../../assets/data/CountryAgeDistribution.types'
 
 export type Scenario = string
 
@@ -54,4 +56,8 @@ export function getScenarioData(key: string): ScenarioData {
   })
 
   return { ...scenarioData, containment: { mitigationIntervals } }
+}
+
+export function getAgeDistribution(country: string): OneCountryAgeDistribution {
+  return (countryAgeDistributionData as CountryAgeDistribution)[country]
 }

--- a/src/components/Main/state/reducer.ts
+++ b/src/components/Main/state/reducer.ts
@@ -5,17 +5,17 @@ import { reducerWithInitialState } from 'typescript-fsa-reducers'
 import immerCase from '../../../state/util/fsaImmerReducer'
 
 import {
-  setScenarioData,
   setPopulationData,
   setEpidemiologicalData,
   setContainmentData,
   setSimulationData,
   setScenario,
+  setAgeDistributionData,
 } from './actions'
 
-import { getScenarioData } from './data'
+import { getScenarioData, getAgeDistribution } from './data'
 
-import { CUSTOM_SCENARIO_NAME, defaultScenarioState } from './state'
+import { CUSTOM_SCENARIO_NAME, CUSTOMIZED_AGE_DISTRIBUTION, defaultScenarioState } from './state'
 
 function maybeAdd<T>(where: T[], what: T): T[] {
   return _.uniq([...where, what])
@@ -45,15 +45,8 @@ export const scenarioReducer = reducerWithInitialState(defaultScenarioState)
       draft.current = name
       if (name !== CUSTOM_SCENARIO_NAME) {
         draft.data = _.cloneDeep(getScenarioData(name))
+        draft.ageDistribution = getAgeDistribution(draft.data.population.country)
       }
-    }),
-  )
-
-  .withHandling(
-    immerCase(setScenarioData, (draft, { data }) => {
-      draft.scenarios = maybeAdd(draft.scenarios, CUSTOM_SCENARIO_NAME)
-      draft.current = CUSTOM_SCENARIO_NAME
-      draft.data = _.cloneDeep(data)
     }),
   )
 
@@ -62,6 +55,9 @@ export const scenarioReducer = reducerWithInitialState(defaultScenarioState)
       draft.scenarios = maybeAdd(draft.scenarios, CUSTOM_SCENARIO_NAME)
       draft.current = CUSTOM_SCENARIO_NAME
       draft.data.population = _.cloneDeep(data)
+      if (draft.data.population.country !== CUSTOMIZED_AGE_DISTRIBUTION) {
+        draft.ageDistribution = getAgeDistribution(draft.data.population.country)
+      }
     }),
   )
 
@@ -91,5 +87,17 @@ export const scenarioReducer = reducerWithInitialState(defaultScenarioState)
       draft.scenarios = maybeAdd(draft.scenarios, CUSTOM_SCENARIO_NAME)
       draft.current = CUSTOM_SCENARIO_NAME
       draft.data.simulation = _.cloneDeep(data)
+    }),
+  )
+
+  .withHandling(
+    immerCase(setAgeDistributionData, (draft, { data }) => {
+      draft.scenarios = maybeAdd(draft.scenarios, CUSTOM_SCENARIO_NAME)
+      draft.current = CUSTOM_SCENARIO_NAME
+      draft.ageDistribution = data
+      draft.data.population = {
+        ...draft.data.population,
+        country: CUSTOMIZED_AGE_DISTRIBUTION,
+      }
     }),
   )

--- a/src/components/Main/state/reducer.ts
+++ b/src/components/Main/state/reducer.ts
@@ -15,7 +15,7 @@ import {
 
 import { getScenarioData, getAgeDistribution } from './data'
 
-import { CUSTOM_SCENARIO_NAME, CUSTOMIZED_AGE_DISTRIBUTION, defaultScenarioState } from './state'
+import { CUSTOM_SCENARIO_NAME, CUSTOM_COUNTRY_NAME, defaultScenarioState } from './state'
 
 function maybeAdd<T>(where: T[], what: T): T[] {
   return _.uniq([...where, what])
@@ -55,7 +55,7 @@ export const scenarioReducer = reducerWithInitialState(defaultScenarioState)
       draft.scenarios = maybeAdd(draft.scenarios, CUSTOM_SCENARIO_NAME)
       draft.current = CUSTOM_SCENARIO_NAME
       draft.data.population = _.cloneDeep(data)
-      if (draft.data.population.country !== CUSTOMIZED_AGE_DISTRIBUTION) {
+      if (draft.data.population.country !== CUSTOM_COUNTRY_NAME) {
         draft.ageDistribution = getAgeDistribution(draft.data.population.country)
       }
     }),
@@ -95,9 +95,6 @@ export const scenarioReducer = reducerWithInitialState(defaultScenarioState)
       draft.scenarios = maybeAdd(draft.scenarios, CUSTOM_SCENARIO_NAME)
       draft.current = CUSTOM_SCENARIO_NAME
       draft.ageDistribution = data
-      draft.data.population = {
-        ...draft.data.population,
-        country: CUSTOMIZED_AGE_DISTRIBUTION,
-      }
+      draft.data.population.country = CUSTOM_COUNTRY_NAME
     }),
   )

--- a/src/components/Main/state/state.ts
+++ b/src/components/Main/state/state.ts
@@ -13,6 +13,7 @@ export interface State {
 // TODO: Add a default category to export
 export const DEFAULT_OVERALL_SCENARIO_NAME = 'CHE-Basel-Stadt'
 export const CUSTOM_SCENARIO_NAME = i18next.t('Custom')
+export const CUSTOMIZED_AGE_DISTRIBUTION = 'Custom'
 
 export const defaultScenarioName = DEFAULT_OVERALL_SCENARIO_NAME
 

--- a/src/components/Main/state/state.ts
+++ b/src/components/Main/state/state.ts
@@ -1,13 +1,13 @@
 import i18next from 'i18next'
-
-import { scenarioNames, getScenarioData } from './data'
-
+import { scenarioNames, getScenarioData, getAgeDistribution } from './data'
 import { ScenarioData } from '../../../algorithms/types/Param.types'
+import { OneCountryAgeDistribution } from '../../../assets/data/CountryAgeDistribution.types'
 
 export interface State {
   scenarios: string[]
   current: string
   data: ScenarioData
+  ageDistribution: OneCountryAgeDistribution
 }
 
 // TODO: Add a default category to export
@@ -16,8 +16,11 @@ export const CUSTOM_SCENARIO_NAME = i18next.t('Custom')
 
 export const defaultScenarioName = DEFAULT_OVERALL_SCENARIO_NAME
 
+const defaultScenarioData = getScenarioData(defaultScenarioName)
+
 export const defaultScenarioState: State = {
   scenarios: scenarioNames,
   current: defaultScenarioName,
-  data: getScenarioData(defaultScenarioName),
+  data: defaultScenarioData,
+  ageDistribution: getAgeDistribution(defaultScenarioData.population.country),
 }

--- a/src/components/Main/state/state.ts
+++ b/src/components/Main/state/state.ts
@@ -13,7 +13,7 @@ export interface State {
 // TODO: Add a default category to export
 export const DEFAULT_OVERALL_SCENARIO_NAME = 'CHE-Basel-Stadt'
 export const CUSTOM_SCENARIO_NAME = i18next.t('Custom')
-export const CUSTOMIZED_AGE_DISTRIBUTION = 'Custom'
+export const CUSTOM_COUNTRY_NAME = 'Custom'
 
 export const defaultScenarioName = DEFAULT_OVERALL_SCENARIO_NAME
 

--- a/src/components/Main/validation/schema.ts
+++ b/src/components/Main/validation/schema.ts
@@ -18,6 +18,8 @@ export const schema = yup.object().shape({
     suspectedCasesToday: yup.number().required(MSG_REQUIRED).min(0, MSG_NON_NEGATIVE),
 
     importsPerDay: yup.number().required(MSG_REQUIRED),
+
+    gjTest: yup.number().required(MSG_REQUIRED),
   }),
 
   epidemiological: yup.object().shape({

--- a/src/components/Main/validation/schema.ts
+++ b/src/components/Main/validation/schema.ts
@@ -3,8 +3,10 @@ import * as yup from 'yup'
 import i18next from 'i18next'
 
 import countryAgeDistribution from '../../../assets/data/country_age_distribution.json'
+import { CUSTOM_COUNTRY_NAME } from '../state/state'
 
 const countries = Object.keys(countryAgeDistribution)
+countries.push(CUSTOM_COUNTRY_NAME)
 
 const MSG_REQUIRED = 'Required'
 const MSG_NON_NEGATIVE = 'Should be non-negative'
@@ -18,8 +20,6 @@ export const schema = yup.object().shape({
     suspectedCasesToday: yup.number().required(MSG_REQUIRED).min(0, MSG_NON_NEGATIVE),
 
     importsPerDay: yup.number().required(MSG_REQUIRED),
-
-    gjTest: yup.number().required(MSG_REQUIRED),
   }),
 
   epidemiological: yup.object().shape({


### PR DESCRIPTION
## Related issues and PRs

- Contributes to #332 
- Supersedes #369
- Punts URL serialization to a new issue yet to be opened.

### Still to do:

- [x] styling - the numbers column is not large enough
- [x] update card help text to reflect the feature
- [x] waiting on feedback re: comments in #332 
- [x] number validation (positive integers)
- [x] age distribution value -> 'Custom'

## Description

Allow customization of age distribution.

## Impacted Areas in the application

Age distribution values.

## Testing

- age distribution values set on initial load
- change when scenario or country drop downs change
- do not change when other form fields change
- edits are passed to run()
- ~~edits persist in the URL~~
- Age distribution country changes to Custom
- Cannot be negative
- Cannot be cleared