### PR TITLE
#382/Experimental fix for UI lag when adding/removing mitigation intervals.

### DIFF
--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -215,8 +215,7 @@ function Main() {
                       autorunSimulation={autorunSimulation}
                       toggleAutorun={togglePersistAutorun}
                       severity={severity}
-                      params={allParams}
-                      mitigation={allParams.containment}
+                      mitigation={scenarioState.data.containment}
                       result={result}
                       caseCounts={empiricalCases}
                       scenarioUrl={scenarioUrl}

--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -174,7 +174,7 @@ function Main() {
       const mitigationIntervals = _.map(newParams.containment.mitigationIntervals, _.cloneDeep)
       scenarioDispatch(setContainmentData({ data: { mitigationIntervals } }))
     }
-  }, 1000)
+  }, 0)
 
   function handleSubmit(params: AllParams, { setSubmitting }: FormikHelpers<AllParams>) {
     updateBrowserUrl()

--- a/src/components/Main/Results/DeterministicLinePlot.tsx
+++ b/src/components/Main/Results/DeterministicLinePlot.tsx
@@ -21,7 +21,7 @@ import { LineProps as RechartsLineProps, YAxisProps } from 'recharts'
 
 import { useTranslation } from 'react-i18next'
 import { AlgorithmResult, UserResult } from '../../../algorithms/types/Result.types'
-import { AllParams, ContainmentData, EmpiricalData } from '../../../algorithms/types/Param.types'
+import { ContainmentData, EmpiricalData } from '../../../algorithms/types/Param.types'
 import { numberFormatter } from '../../../helpers/numberFormat'
 
 import { calculatePosition, scrollToRef } from './chartHelper'

--- a/src/components/Main/Results/DeterministicLinePlot.tsx
+++ b/src/components/Main/Results/DeterministicLinePlot.tsx
@@ -70,7 +70,6 @@ export const colors = {
 export interface LinePlotProps {
   data?: AlgorithmResult
   userResult?: UserResult
-  params: AllParams
   mitigation: ContainmentData
   logScale?: boolean
   showHumanized?: boolean
@@ -100,7 +99,6 @@ function legendFormatter(enabledPlots: string[], value: string, entry: any) {
 export function DeterministicLinePlot({
   data,
   userResult,
-  params,
   mitigation,
   logScale,
   showHumanized,

--- a/src/components/Main/Results/DeterministicLinePlot.tsx
+++ b/src/components/Main/Results/DeterministicLinePlot.tsx
@@ -145,12 +145,6 @@ export function DeterministicLinePlot({
     newCases: nonEmptyCaseCounts?.filter((d, i) => newCases(nonEmptyCaseCounts, i)).length ?? 0,
     hospitalized: nonEmptyCaseCounts?.filter((d) => d.hospitalized).length ?? 0,
   }
-  const mitigationsToPlot = mitigationIntervals.map((d) => ({
-    key: d.name,
-    color: '#CCCCCC',
-    legendType: 'line',
-    name: d.name,
-  }))
 
   const observations =
     nonEmptyCaseCounts?.map((d, i) => ({

--- a/src/components/Main/Results/ResultsCard.tsx
+++ b/src/components/Main/Results/ResultsCard.tsx
@@ -33,6 +33,8 @@ interface ResultsCardProps {
   scenarioUrl?: string
 }
 
+const MemoizedDeterministicLinePlot = React.memo(DeterministicLinePlot)
+
 function ResultsCardFunction({
   canRun,
   autorunSimulation,
@@ -189,7 +191,7 @@ function ResultsCardFunction({
         </Row>
         <Row noGutters>
           <Col>
-            <DeterministicLinePlot
+            <MemoizedDeterministicLinePlot
               data={result}
               userResult={userResult}
               mitigation={mitigation}

--- a/src/components/Main/Results/ResultsCard.tsx
+++ b/src/components/Main/Results/ResultsCard.tsx
@@ -26,7 +26,6 @@ interface ResultsCardProps {
   autorunSimulation: boolean
   toggleAutorun: () => void
   canRun: boolean
-  params: AllParams
   mitigation: ContainmentData
   severity: SeverityTableRow[] // TODO: pass severity throughout the algorithm and as a part of `AlgorithmResult` instead?
   result?: AlgorithmResult
@@ -38,7 +37,6 @@ function ResultsCardFunction({
   canRun,
   autorunSimulation,
   toggleAutorun,
-  params,
   mitigation,
   severity,
   result,
@@ -194,7 +192,6 @@ function ResultsCardFunction({
             <DeterministicLinePlot
               data={result}
               userResult={userResult}
-              params={params}
               mitigation={mitigation}
               logScale={logScale}
               showHumanized={showHumanized}

--- a/src/components/Main/Results/ResultsCard.tsx
+++ b/src/components/Main/Results/ResultsCard.tsx
@@ -11,7 +11,7 @@ import { AlgorithmResult, UserResult } from '../../../algorithms/types/Result.ty
 import { CollapsibleCard } from '../../Form/CollapsibleCard'
 import { ComparisonModalWithButton } from '../Compare/ComparisonModalWithButton'
 import { DeterministicLinePlot } from './DeterministicLinePlot'
-import { AllParams, ContainmentData, EmpiricalData } from '../../../algorithms/types/Param.types'
+import { ContainmentData, EmpiricalData } from '../../../algorithms/types/Param.types'
 import { FileType } from '../Compare/FileUploadZone'
 import { OutcomeRatesTable } from './OutcomeRatesTable'
 import { readFile } from '../../../helpers/readFile'


### PR DESCRIPTION
## Related issues and PRs

#382 

## Description

This PR tries to fix the UI lag when adding a new mitigation interval. It removes the debounce delay in `setScenarioCustom()`. The reason for debounce isn't immediately obvious, I hypothesize that it's unnecessary, and am drafting this PR for feedback/testing.

Looks like the primary source of delay is the Deterministic line plot. Wrapping it in a `React.memo()` greatly improves the lag.

## Impacted Areas in the application

- Mitigation interval UI
- Possibly the DeterministicLinePlot component, because it is now wrapped with `React.memo()`

## Testing

Start a dev server, load the app, scroll to the Mitigation section, click "Add" to add a new interval, click the trash icon to remove it:

![add-mitigation-interval](https://user-images.githubusercontent.com/1462268/78456276-b860fc80-7670-11ea-8d74-827ced250e4d.gif)
