### PR TITLE
test: add tests for scenarios

### DIFF
--- a/cypress/integration/scenarios.spec.ts
+++ b/cypress/integration/scenarios.spec.ts
@@ -45,6 +45,8 @@ context('Language switcher', () => {
   })
 
   for (const scenarioKey of firstTenScenarios) {
+    const { population } = scenarios[scenarioKey];
+
     describe(`Switching to "${scenarioKey}"`, () => {
       it(`should change the text on selector to "${scenarioKey}" correctly`, () => {
         cy.get('@ScenarioDropdown')
@@ -56,6 +58,16 @@ context('Language switcher', () => {
         cy.get('@ScenarioDropdown')
           .find('[class$="singleValue"]')
           .should('have.text', scenarioKey)
+      })
+
+      it('should change the values for the "Population" card', () => {
+        cy.get('.card--population').as('PopulationCard')
+
+        for (const key in population) {
+          cy.get('@PopulationCard')
+            .find(`[name="population.${key}"]`)
+            .should('have.value', String(population[key]))
+        }
       })
     })
   }

--- a/cypress/integration/scenarios.spec.ts
+++ b/cypress/integration/scenarios.spec.ts
@@ -6,7 +6,7 @@ const scenariosKeys = Object.keys(scenarios);
 // testing all the scenarios would be extremely long
 const firstTenScenarios = scenariosKeys.slice(0, 10);
 
-context('Language switcher', () => {
+context('Scenario selector', () => {
   before(() => {
     cy.visit(Cypress.env('BASE_URL'))
     cy.closeDisclaimer()
@@ -14,6 +14,8 @@ context('Language switcher', () => {
 
   beforeEach(() => {
     cy.get('#scenarioName').as('ScenarioDropdown')
+    cy.get('.card--population').as('PopulationCard')
+    cy.get('.card--epidemiology').as('EpidemiologyCard')
   })
 
   describe('The scenario selector', () => {
@@ -45,15 +47,16 @@ context('Language switcher', () => {
   })
 
   for (const scenarioKey of firstTenScenarios) {
-    const { population } = scenarios[scenarioKey];
+    const { epidemiological, population } = scenarios[scenarioKey];
 
     describe(`Switching to "${scenarioKey}"`, () => {
       it(`should change the text on selector to "${scenarioKey}" correctly`, () => {
         cy.get('@ScenarioDropdown')
           .click()
-          .find('[class$="-menu"]')
           .findByText(scenarioKey)
           .click()
+
+        cy.wait(100) // updating the selectbox can take some time
 
         cy.get('@ScenarioDropdown')
           .find('[class$="singleValue"]')
@@ -61,12 +64,18 @@ context('Language switcher', () => {
       })
 
       it('should change the values for the "Population" card', () => {
-        cy.get('.card--population').as('PopulationCard')
-
         for (const key in population) {
           cy.get('@PopulationCard')
             .find(`[name="population.${key}"]`)
             .should('have.value', String(population[key]))
+        }
+      })
+
+      it('should change the values for the "Epidemiology" card', () => {
+        for (const key in epidemiological) {
+          cy.get('@EpidemiologyCard')
+            .find(`[name="epidemiological.${key}"]`)
+            .should('have.value', String(epidemiological[key]))
         }
       })
     })

--- a/cypress/integration/scenarios.spec.ts
+++ b/cypress/integration/scenarios.spec.ts
@@ -2,9 +2,9 @@
 
 import scenarios from '../../src/assets/data/scenarios/scenarios.json'
 
-const scenariosKeys = Object.keys(scenarios);
+const scenariosKeys = Object.keys(scenarios)
 // testing all the scenarios would be extremely long
-const firstTenScenarios = scenariosKeys.slice(0, 10);
+const firstTenScenarios = scenariosKeys.slice(0, 10)
 
 context('Scenario selector', () => {
   before(() => {
@@ -20,15 +20,11 @@ context('Scenario selector', () => {
 
   describe('The scenario selector', () => {
     it('should be present', () => {
-      cy.get('@ScenarioDropdown')
-        .should('be.visible')
+      cy.get('@ScenarioDropdown').should('be.visible')
     })
 
     it('should open when clicking on it', () => {
-      cy.get('@ScenarioDropdown')
-        .click()
-        .find('[class$="-menu"]')
-        .should('exist')
+      cy.get('@ScenarioDropdown').click().find('[class$="-menu"]').should('exist')
     })
 
     it(`should have ${scenariosKeys.length} options`, () => {
@@ -39,35 +35,25 @@ context('Scenario selector', () => {
     })
 
     it('should close when clicking on it a second time', () => {
-      cy.get('@ScenarioDropdown')
-        .click()
-        .find('[class$="-menu"]')
-        .should('not.exist')
+      cy.get('@ScenarioDropdown').click().find('[class$="-menu"]').should('not.exist')
     })
   })
 
   for (const scenarioKey of firstTenScenarios) {
-    const { epidemiological, population } = scenarios[scenarioKey];
+    const { epidemiological, population } = scenarios[scenarioKey]
 
     describe(`Switching to "${scenarioKey}"`, () => {
       it(`should change the text on selector to "${scenarioKey}" correctly`, () => {
-        cy.get('@ScenarioDropdown')
-          .click()
-          .findByText(scenarioKey)
-          .click()
+        cy.get('@ScenarioDropdown').click().findByText(scenarioKey).click()
 
         cy.wait(100) // updating the selectbox can take some time
 
-        cy.get('@ScenarioDropdown')
-          .find('[class$="singleValue"]')
-          .should('have.text', scenarioKey)
+        cy.get('@ScenarioDropdown').find('[class$="singleValue"]').should('have.text', scenarioKey)
       })
 
       it('should change the values for the "Population" card', () => {
         for (const key in population) {
-          cy.get('@PopulationCard')
-            .find(`[name="population.${key}"]`)
-            .should('have.value', String(population[key]))
+          cy.get('@PopulationCard').find(`[name="population.${key}"]`).should('have.value', String(population[key]))
         }
       })
 

--- a/cypress/integration/scenarios.spec.ts
+++ b/cypress/integration/scenarios.spec.ts
@@ -1,0 +1,62 @@
+/// <reference types="cypress" />
+
+import scenarios from '../../src/assets/data/scenarios/scenarios.json'
+
+const scenariosKeys = Object.keys(scenarios);
+// testing all the scenarios would be extremely long
+const firstTenScenarios = scenariosKeys.slice(0, 10);
+
+context('Language switcher', () => {
+  before(() => {
+    cy.visit(Cypress.env('BASE_URL'))
+    cy.closeDisclaimer()
+  })
+
+  beforeEach(() => {
+    cy.get('#scenarioName').as('ScenarioDropdown')
+  })
+
+  describe('The scenario selector', () => {
+    it('should be present', () => {
+      cy.get('@ScenarioDropdown')
+        .should('be.visible')
+    })
+
+    it('should open when clicking on it', () => {
+      cy.get('@ScenarioDropdown')
+        .click()
+        .find('[class$="-menu"]')
+        .should('exist')
+    })
+
+    it(`should have ${scenariosKeys.length} options`, () => {
+      cy.get('@ScenarioDropdown')
+        .find('[class$="-menu"]')
+        .find('[class$="-option"]')
+        .should('have.length', scenariosKeys.length)
+    })
+
+    it('should close when clicking on it a second time', () => {
+      cy.get('@ScenarioDropdown')
+        .click()
+        .find('[class$="-menu"]')
+        .should('not.exist')
+    })
+  })
+
+  for (const scenarioKey of firstTenScenarios) {
+    describe(`Switching to "${scenarioKey}"`, () => {
+      it(`should change the text on selector to "${scenarioKey}" correctly`, () => {
+        cy.get('@ScenarioDropdown')
+          .click()
+          .find('[class$="-menu"]')
+          .findByText(scenarioKey)
+          .click()
+
+        cy.get('@ScenarioDropdown')
+          .find('[class$="singleValue"]')
+          .should('have.text', scenarioKey)
+      })
+    })
+  }
+})

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -12,6 +12,7 @@
 // This function is called when a project is opened or re-opened (e.g. due to
 // the project's config changing)
 
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const webpack = require('@cypress/webpack-preprocessor')
 
 /**

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -12,7 +12,7 @@
 // This function is called when a project is opened or re-opened (e.g. due to
 // the project's config changing)
 
-import webpack from '@cypress/webpack-preprocessor'
+const webpack = require('@cypress/webpack-preprocessor')
 
 /**
  * @type {Cypress.PluginConfig}

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -27,6 +27,9 @@
 import '@testing-library/cypress/add-commands'
 
 Cypress.Commands.add('closeDisclaimer', () => {
+  cy.url().should('include', '/start')
+  cy.get('.landing-page__simulate-link').click()
+
   cy.findByText('COVID-19 Scenario Disclaimer').should('exist').next().click()
 
   cy.findByText('COVID-19 Scenario Disclaimer').should('not.exist')


### PR DESCRIPTION
## Related issues and PRs
Contributes to #119  

## Description
Adding e2e tests for the scenario selector
- select a different scenario
- the correct values are set in the population card
- the correct values are set in the epidemiology card

## Impacted Areas in the application
Tests

## Testing
run `yarn e2e` for a full test run
run `yarn e2e -s "**/scenario*"` to only run the scenario tests

![scenariospec](https://user-images.githubusercontent.com/6505742/78468822-3a772100-7756-11ea-8aca-9e1c4b7cf81b.jpg)
