### PR TITLE
Fix/date serialization

### DIFF
--- a/src/components/Main/state/serialization/DtoConverter.ts
+++ b/src/components/Main/state/serialization/DtoConverter.ts
@@ -22,9 +22,7 @@ import { MitigationInterval } from '../../../../algorithms/types/Param.types'
  */
 const getTime = (potentialDate: Date | string): number => {
   if (typeof potentialDate === 'string') {
-    try {
-      return new Date(potentialDate).getTime()
-    } catch (error) {}
+    return new Date(potentialDate).getTime()
   }
 
   try {

--- a/src/components/Main/state/serialization/DtoConverter.ts
+++ b/src/components/Main/state/serialization/DtoConverter.ts
@@ -22,7 +22,9 @@ import { MitigationInterval } from '../../../../algorithms/types/Param.types'
  */
 const getTime = (potentialDate: Date | string): number => {
   if (typeof potentialDate === 'string') {
-    return 0 // epoch zero (1 January 1970)
+    try {
+      return new Date(potentialDate).getTime()
+    } catch (error) {}
   }
 
   try {


### PR DESCRIPTION
## Related issues and PRs

#409 

## Description
This adds a simple (brittle) conversion from the simulation.timeRange date  strings '%Y-%m-%d' to a  date object and timestamp. This is most likely not how this should work. But it fixes the bug. 

## Impacted Areas in the application
conversion of the state to object that goes into serialization.

