### PR TITLE
Add age distribution to serialization

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
     "@types/html-webpack-plugin": "3.2.2",
     "@types/jest": "25.1.4",
     "@types/jest-axe": "3.2.1",
+    "@types/jsurl": "1.2.28",
     "@types/jszip": "3.1.7",
     "@types/loadable__component": "5.10.0",
     "@types/lodash": "4.14.149",

--- a/src/components/Main/state/serialization/DtoConverter.ts
+++ b/src/components/Main/state/serialization/DtoConverter.ts
@@ -61,6 +61,7 @@ export const toDto = (state: PersistedState): PersistedStateDto => {
       },
       numberStochasticRuns: clone.data.simulation.numberStochasticRuns,
     },
+    ageDistribution: clone.ageDistribution,
   }
 }
 
@@ -90,5 +91,6 @@ export const fromDto = (dto: PersistedStateDto): PersistedState => {
         numberStochasticRuns: dto.simulation.numberStochasticRuns,
       },
     },
+    ageDistribution: dto.ageDistribution,
   }
 }

--- a/src/components/Main/state/serialization/types/PersistedState.types.ts
+++ b/src/components/Main/state/serialization/types/PersistedState.types.ts
@@ -1,7 +1,9 @@
 import { ScenarioData } from '../../../../../algorithms/types/Param.types'
+import { OneCountryAgeDistribution } from '../../../../../assets/data/CountryAgeDistribution.types'
 
 // part of the application state to be persisted in the URL
 export interface PersistedState {
   current: string
   data: ScenarioData
+  ageDistribution: OneCountryAgeDistribution
 }

--- a/src/components/Main/state/serialization/types/PersistedStateDto.types.ts
+++ b/src/components/Main/state/serialization/types/PersistedStateDto.types.ts
@@ -1,4 +1,5 @@
 import { EpidemiologicalData, PopulationData } from '../../../../../algorithms/types/Param.types'
+import { OneCountryAgeDistribution } from '../../../../../assets/data/CountryAgeDistribution.types'
 
 export interface DateRangeDto {
   tMin?: number
@@ -32,4 +33,5 @@ export interface PersistedStateDto {
   epidemiological: EpidemiologicalData
   simulation: SimulationDataDto
   containment: MitigationIntervalDto[]
+  ageDistribution: OneCountryAgeDistribution
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2179,6 +2179,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
   integrity sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==
 
+"@types/jsurl@1.2.28":
+  version "1.2.28"
+  resolved "https://registry.yarnpkg.com/@types/jsurl/-/jsurl-1.2.28.tgz#03430a7cc878d1415c5b3cb03547ff238bc7a75c"
+  integrity sha1-A0MKfMh40UFcWzywNUf/I4vHp1w=
+
 "@types/jszip@3.1.7":
   version "3.1.7"
   resolved "https://registry.yarnpkg.com/@types/jszip/-/jszip-3.1.7.tgz#c45bd72b448b3fb002125282c57c36190247cb34"


### PR DESCRIPTION
## Related issues and PRs

Fixes #332 (final bit)

## Description

Adds any modifications to the age distribution fields to the serialized URL so they persist over shares and new tabs.

## Impacted Areas in the application

Custom age distributions.

## Testing

Change an age pop number.
Open in new tab - check that the change persists.
Reload - check that the change persists.
New browser - check that the change persists.