### PR TITLE
fix: Changing the Action column name

### DIFF
--- a/src/components/Main/Results/ExportSimulationDialog.tsx
+++ b/src/components/Main/Results/ExportSimulationDialog.tsx
@@ -25,7 +25,7 @@ export default function ExportSimulationDialog({ showModal, toggleShowModal, res
               <th>{t('Filename')}</th>
               <th>{t('Description')}</th>
               <th>{t('Format')}</th>
-              <th>{t('Download')}</th>
+              <th>{t('Action')}</th>
             </tr>
           </thead>
           <tbody>


### PR DESCRIPTION
## Description
<!-- Goal of the pull request -->

The last column of the table should be renamed, because the "Copy URL" option is not a download:

![image](https://user-images.githubusercontent.com/1078403/78510992-0cfb9900-7791-11ea-8508-591ef8d4a39b.png)

I'm proposing a better name:

![Snag_54ab2874](https://user-images.githubusercontent.com/1078403/78510998-15ec6a80-7791-11ea-8e20-e8bd13a54af5.png)
