### PR TITLE
feat: Introducing URL format versioning

### DIFF
--- a/src/components/Main/state/serialization/StateSerializer.test.ts
+++ b/src/components/Main/state/serialization/StateSerializer.test.ts
@@ -57,24 +57,24 @@ const STATE: State = {
   },
 }
 
-const SERIALIZED_STRING =
+const SERIALIZED_STATE =
   "~(current~'CHE-Basel-Stadt~containment~(~(id~'06ad1640-ce01-41c0-8dc2-78fbbfbd8dd6~name~'Intervention*20*231~color~'*23bf5b17~mitigationValue~0.2~timeRange~(tMin~1583971200000~tMax~1598918400000))~(id~'a353e47f-ed52-4517-9cb5-063878edbbca~name~'Intervention*20*232~color~'*23666666~mitigationValue~0.6~timeRange~(tMin~1585440000000~tMax~1598918400000)))~population~(ICUBeds~80~cases~'CHE-Basel-Stadt~country~'Switzerland~hospitalBeds~698~importsPerDay~0.1~populationServed~195000~suspectedCasesToday~10)~epidemiological~(infectiousPeriod~3~latencyTime~5~lengthHospitalStay~4~lengthICUStay~14~overflowSeverity~2~peakMonth~0~r0~2~seasonalForcing~0.2)~simulation~(simulationTimeRange~(tMin~1580428800000~tMax~1598918400000)~numberStochasticRuns~0))"
 
-const SERIALIZED_STRING_AUSTRIA =
+const SERIALIZED_STATE_AUSTRIA =
   "~(current~'Austria~containment~(~(id~'06ad1640-ce01-41c0-8dc2-78fbbfbd8dd6~name~'Intervention*20*231~color~'*23bf5b17~mitigationValue~0.2~timeRange~(tMin~1583971200000~tMax~1598918400000))~(id~'a353e47f-ed52-4517-9cb5-063878edbbca~name~'Intervention*20*232~color~'*23666666~mitigationValue~0.6~timeRange~(tMin~1585440000000~tMax~1598918400000)))~population~(ICUBeds~80~cases~'CHE-Basel-Stadt~country~'Switzerland~hospitalBeds~698~importsPerDay~0.1~populationServed~195000~suspectedCasesToday~10)~epidemiological~(infectiousPeriod~3~latencyTime~5~lengthHospitalStay~4~lengthICUStay~14~overflowSeverity~2~peakMonth~0~r0~2~seasonalForcing~0.2)~simulation~(simulationTimeRange~(tMin~1580428800000~tMax~1598918400000)~numberStochasticRuns~0))"
 
 describe('StateSerializer', () => {
   it('serializes the state', () => {
-    expect(serialize(STATE)).toBe(SERIALIZED_STRING)
+    expect(serialize(STATE)).toBe(SERIALIZED_STATE)
   })
 
   describe('deserializes the state', () => {
     it('from query string that fully represents current state', () => {
-      expect(deserialize(SERIALIZED_STRING, STATE)).toEqual(STATE)
+      expect(deserialize(SERIALIZED_STATE, STATE)).toEqual(STATE)
     })
 
     it('from query string that does not represent current state', () => {
-      expect(deserialize(SERIALIZED_STRING_AUSTRIA, STATE)).toEqual({
+      expect(deserialize(SERIALIZED_STATE_AUSTRIA, STATE)).toEqual({
         ...STATE,
         current: 'Austria',
       })

--- a/src/components/Main/state/serialization/URLSerializer.test.ts
+++ b/src/components/Main/state/serialization/URLSerializer.test.ts
@@ -1,5 +1,5 @@
 import { State } from '../state'
-import { serializeScenarioToURL } from './URLSerializer'
+import { buildLocationSearch, updateBrowserURL } from './URLSerializer'
 
 const SCENARIOS = ['CHE-Basel-Landschaft', 'CHE-Basel-Stadt']
 
@@ -57,17 +57,22 @@ const STATE: State = {
   },
 }
 
-const SERIALIZED_STRING =
+const SERIALIZED_STATE =
   "~(current~'CHE-Basel-Stadt~containment~(~(id~'06ad1640-ce01-41c0-8dc2-78fbbfbd8dd6~name~'Intervention*20*231~color~'*23bf5b17~mitigationValue~0.2~timeRange~(tMin~1583971200000~tMax~1598918400000))~(id~'a353e47f-ed52-4517-9cb5-063878edbbca~name~'Intervention*20*232~color~'*23666666~mitigationValue~0.6~timeRange~(tMin~1585440000000~tMax~1598918400000)))~population~(ICUBeds~80~cases~'CHE-Basel-Stadt~country~'Switzerland~hospitalBeds~698~importsPerDay~0.1~populationServed~195000~suspectedCasesToday~10)~epidemiological~(infectiousPeriod~3~latencyTime~5~lengthHospitalStay~4~lengthICUStay~14~overflowSeverity~2~peakMonth~0~r0~2~seasonalForcing~0.2)~simulation~(simulationTimeRange~(tMin~1580428800000~tMax~1598918400000)~numberStochasticRuns~0))"
+const LOCATION_SEARCH = `?v=1&q=${SERIALIZED_STATE}`
 
 describe('URLSerializer', () => {
   afterEach(jest.clearAllMocks)
 
-  it('serializes scenario and pushes it to browser history', () => {
+  it('serializes application state and builds the location.search', () => {
+    expect(buildLocationSearch(STATE)).toBe(LOCATION_SEARCH)
+  })
+
+  it('pushes to browser history', () => {
     const spy = jest.spyOn(history, 'pushState')
 
-    serializeScenarioToURL(STATE)
+    updateBrowserURL('?foo=1&bar=baz')
 
-    expect(spy).toHaveBeenCalledWith('', '', `?${SERIALIZED_STRING}`)
+    expect(spy).toHaveBeenCalledWith('', '', '?foo=1&bar=baz')
   })
 })

--- a/src/components/Main/state/serialization/URLSerializer.ts
+++ b/src/components/Main/state/serialization/URLSerializer.ts
@@ -2,25 +2,59 @@ import { State } from '../state'
 import { serialize, deserialize } from './StateSerializer'
 
 /**
+ * The reason for URL format versioning is because in the future we might completely change the way we serialize state to the URL
+ * For instance, maybe the amount of data needed to be persisted grows behind any advisable size, so we'll have to provide a stronger compression
+ * At that point, we might choose to replace JSURL with something else
+ * However, our users could still have the old link bookmarked accessible from some old email
+ * That's why we need version, as a separate link variable
+ * By reading the version first, and then applying a query deserialization for that version, we're ensuring backward compatibility
+ * Once we eventually start using de/serializer version 2, the old deserializer (but not the serializer) should still be in our codebase,
+ * and there should be a switch..case on the version, for using the right deserializer
+ */
+const VERSION_PARAM_NAME = 'v'
+const QUERY_PARAM_NAME = 'q'
+const CURRENT_VERSION = '1'
+const VALID_VERSIONS = [CURRENT_VERSION]
+
+/**
  * Layer responsible for pushing the serialized state to browser history and reading it from the URL
  */
 
-export const serializeScenarioToURL = (scenarioState: State) => {
+/**
+ * Builds a string in a form of "?v=1&q=datablob"
+ */
+export const buildLocationSearch = (scenarioState: State): string => {
   const queryString = serialize(scenarioState)
 
-  window.history.pushState('', '', `?${queryString}`)
+  return `?${VERSION_PARAM_NAME}=${CURRENT_VERSION}&${QUERY_PARAM_NAME}=${queryString}`
 }
 
+/**
+ * Updates browser search with a given URL
+ */
+export const updateBrowserURL = (searchString: string): void => {
+  window.history.pushState('', '', searchString)
+}
+
+/**
+ * Reads the browser URL and returna the updated application state
+ */
 export const deserializeScenarioFromURL = (currentAppState: State): State => {
   const { search } = window.location
 
   if (search) {
-    const queryString = search.slice(1) // removing the first char ('?')
+    const searchParams = new URLSearchParams(search.slice(1)) // removing the first char ('?')
+    const version = searchParams.get(VERSION_PARAM_NAME)
+    const queryString = searchParams.get(QUERY_PARAM_NAME)
 
-    try {
-      return deserialize(queryString, currentAppState)
-    } catch (error) {
-      console.error('Error while parsing URL :', error.message)
+    if (!version || !VALID_VERSIONS.includes(version)) {
+      console.error('Invalid URL version:', version)
+    } else if (queryString) {
+      try {
+        return deserialize(queryString, currentAppState)
+      } catch (error) {
+        console.error('Error while parsing URL:', error.message)
+      }
     }
   }
 


### PR DESCRIPTION
## Description
<!-- Goal of the pull request -->
Previously there were no named parameters in the URL's `location.search`. We're introducing the version variable, as well as the query variable.

 * The reason for URL format versioning is because in the future we might completely change the way we serialize state to the URL
 * For instance, maybe the amount of data needed to be persisted grows behind any advisable size, so we'll have to provide a stronger compression
 * At that point, we might choose to replace JSURL with something else
 * However, our users could still have the old link bookmarked accessible from some old email
 * That's why we need version, as a separate link variable
 * By reading the version first, and then applying a query deserialization for that version, we're ensuring backward compatibility
 * Once we eventually start using de/serializer version 2, the old deserializer (but not the serializer) should still be in our codebase,
 * and there should be a switch..case on the version, for using the right deserializer

This is how the new link looks like:

http://localhost:3000/?v=1&q=~(current~%27Austria~containment~(~(id~%27bf589adf-65aa-441f-be1e-b163b212e6b5~name~%27Intervention*20*231~color~%27*23bf5b17~mitigationValue~0.4~timeRange~(tMin~1584835200000~tMax~1598918400000)))~population~(ICUBeds~1833~cases~%27Austria~country~%27Austria~hospitalBeds~49395~importsPerDay~0.1~populationServed~9006000~suspectedCasesToday~8)~epidemiological~(infectiousPeriod~3~latencyTime~3~lengthHospitalStay~4~lengthICUStay~14~overflowSeverity~2~peakMonth~0~r0~2.8~seasonalForcing~0)~simulation~(simulationTimeRange~(tMin~1581465600000~tMax~1598918400000)~numberStochasticRuns~0))

![version](https://user-images.githubusercontent.com/1078403/78512782-3d4a3400-779f-11ea-8fdd-c4ea0fb5a60a.png)

## Impacted Areas in the application
<!-- Components of the application that this PR will change -->
- URLSerializer.ts
- Main.tsx

## Testing
<!-- Steps to test the changes proposed by this PR -->
- Open the application and change parameters
- Hit the "Run" button and ensure that the URL is in form of `?v=1&q=serializedState`
- Reload the page and ensure parameters persisted in the URL have been re-applied
