### PR TITLE
Sharan/persistent scenarios

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,8 @@
     "@devexpress/dx-react-grid-bootstrap4": "2.5.1",
     "@loadable/component": "5.12.0",
     "@types/mathjs": "^6.0.4",
+    "adaptivecards": "1.2.5",
+    "adaptivecards-templating": "0.1.1-alpha.1",
     "animate.css": "3.7.2",
     "axios": "0.19.2",
     "bootstrap": "4.4.1",

--- a/src/components/Form/FormTextField.tsx
+++ b/src/components/Form/FormTextField.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+
+import { Field, FieldProps, FormikErrors, FormikTouched, FormikValues } from 'formik'
+import { FormGroup, Row, Col } from 'reactstrap'
+import FormLabel from './FormLabel'
+
+export interface FormTextFieldProps<ValueType extends string | number> {
+  identifier: string
+  label: string
+  help?: string | React.ReactNode
+}
+
+export function FormTextField({ identifier, label, help }: FormTextFieldProps<string>) {
+  return (
+    <Field name={identifier}>
+      {({ field: { value, onBlur }, form: { setFieldValue } }: FieldProps<string>) => {
+        return (
+          <FormGroup className="my-0">
+            <Row noGutters>
+              <Col>
+                <FormLabel identifier={identifier} label={label} help={help} />
+              </Col>
+              <Col>
+                <input
+                  id={identifier}
+                  type="text"
+                  value={value}
+                  onChange={(value) => {
+                    setFieldValue?.(identifier, value.target.value)
+                  }}
+                  onBlur={onBlur}
+                />
+              </Col>
+            </Row>
+          </FormGroup>
+        )
+      }}
+    </Field>
+  )
+}

--- a/src/components/Main/Main.scss
+++ b/src/components/Main/Main.scss
@@ -4,6 +4,7 @@ $button-spacing: 5px;
 .compare-button,
 .export-button,
 .new-tab-button,
+.save-button,
 .run-button {
   width: $button-width;
   margin-left: $button-spacing;

--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -36,6 +36,7 @@ import { updateSeverityTable } from './Scenario/severityTableUpdate'
 
 import './Main.scss'
 import { TimeSeries } from '../../algorithms/types/TimeSeries.types'
+import { SavedScenario } from './state/savedScenario'
 
 export function severityTableIsValid(severity: SeverityTableRow[]) {
   return !severity.some((row) => _.values(row?.errors).some((x) => x !== undefined))
@@ -182,6 +183,34 @@ function Main() {
     setSubmitting(false)
   }
 
+  function saveScenario(name: string, creator: string) {
+    // Read saved scenarios from local storage
+    let existingSavedScenarios = LocalStorage.get<SavedScenario[]>(LOCAL_STORAGE_KEYS.SAVED_SCENARIOS)
+
+    // if null, construct a new object
+    if (!existingSavedScenarios) {
+      existingSavedScenarios = []
+    }
+
+    // Construct an object for the current scenario
+    const currDateTimeUTC: string = new Date().toUTCString()
+
+    // construct the url query string from the state variable rather than reading
+    // from the browser url directly which might have been edited by the user
+    const scenarioUrl: string = `/?${scenarioQueryString}`
+
+    const currentScenario: SavedScenario = {
+      name,
+      creationTime: currDateTimeUTC,
+      creator,
+      url: scenarioUrl,
+    }
+    existingSavedScenarios.push(currentScenario)
+
+    // save it back to local storage
+    LocalStorage.set(LOCAL_STORAGE_KEYS.SAVED_SCENARIOS, existingSavedScenarios)
+  }
+
   return (
     <Row>
       <Col md={12}>
@@ -220,6 +249,7 @@ function Main() {
                       result={result}
                       caseCounts={empiricalCases}
                       scenarioUrl={scenarioUrl}
+                      onSave={saveScenario}
                     />
                   </Col>
                 </Row>

--- a/src/components/Main/Results/ExportSimulationDialog.tsx
+++ b/src/components/Main/Results/ExportSimulationDialog.tsx
@@ -65,7 +65,7 @@ export default function ExportSimulationDialog({ showModal, toggleShowModal, res
         <Button color="secondary" disabled={!result} onClick={() => result && exportAll(result)}>
           {t('Download all as zip')}
         </Button>
-        <Button color="primary" onClick={toggleShowModal}>
+        <Button color="primary" type="submit" onClick={toggleShowModal}>
           {t('Done')}
         </Button>
       </ModalFooter>

--- a/src/components/Main/Results/ExportSimulationDialog.tsx
+++ b/src/components/Main/Results/ExportSimulationDialog.tsx
@@ -65,7 +65,7 @@ export default function ExportSimulationDialog({ showModal, toggleShowModal, res
         <Button color="secondary" disabled={!result} onClick={() => result && exportAll(result)}>
           {t('Download all as zip')}
         </Button>
-        <Button color="primary" type="submit" onClick={toggleShowModal}>
+        <Button color="primary" onClick={toggleShowModal}>
           {t('Done')}
         </Button>
       </ModalFooter>

--- a/src/components/Main/Results/ResultsCard.scss
+++ b/src/components/Main/Results/ResultsCard.scss
@@ -15,6 +15,40 @@
   }
 }
 
+.modal-btn-container {
+  display: flex;
+
+  button {
+    margin: 0 0.5em 0 0;
+    text-transform: uppercase;
+  }
+
+  > button:last-of-type {
+    margin: 0;
+  }
+
+  button:not([hidden]) {
+    flex: 100%;
+  }
+}
+
+@media (min-width: 768px) {
+  .modal-btn-container {
+    display: inline-block;   
+    button {
+      margin: 0 0.5em 0 0;
+      text-transform: uppercase;
+    }
+  
+    > button:last-of-type {
+      margin: 0;
+    }
+  
+    button:not([hidden]) {
+      flex: 100%;
+    }
+  }
+}
 .form-check-label {
   font-size: 80%;
   margin-bottom: 1.5rem;

--- a/src/components/Main/Results/ResultsCard.tsx
+++ b/src/components/Main/Results/ResultsCard.tsx
@@ -11,13 +11,14 @@ import { AlgorithmResult, UserResult } from '../../../algorithms/types/Result.ty
 import { CollapsibleCard } from '../../Form/CollapsibleCard'
 import { ComparisonModalWithButton } from '../Compare/ComparisonModalWithButton'
 import { DeterministicLinePlot } from './DeterministicLinePlot'
-import { AllParams, ContainmentData, EmpiricalData } from '../../../algorithms/types/Param.types'
+import { AllParams, ContainmentData, EmpiricalData, ScenarioData } from '../../../algorithms/types/Param.types'
 import { FileType } from '../Compare/FileUploadZone'
 import { OutcomeRatesTable } from './OutcomeRatesTable'
 import { readFile } from '../../../helpers/readFile'
 import { SeverityTableRow } from '../Scenario/SeverityTable'
 import LinkButton from '../../Buttons/LinkButton'
 import './ResultsCard.scss'
+import SaveSimulationDialog from './SaveSimulationDialog'
 
 const LOG_SCALE_DEFAULT = true
 const SHOW_HUMANIZED_DEFAULT = true
@@ -32,6 +33,7 @@ interface ResultsCardProps {
   result?: AlgorithmResult
   caseCounts?: EmpiricalData
   scenarioUrl?: string
+  onSave: (name: string, creator: string) => void
 }
 
 function ResultsCardFunction({
@@ -44,6 +46,7 @@ function ResultsCardFunction({
   result,
   caseCounts,
   scenarioUrl,
+  onSave,
 }: ResultsCardProps) {
   const { t } = useTranslation()
   const [logScale, setLogScale] = useState(LOG_SCALE_DEFAULT)
@@ -90,6 +93,10 @@ function ResultsCardFunction({
     setUserResult(newUserResult)
   }
 
+  const [canSave, setCanSave] = useState<boolean>(false)
+  const [showSaveModal, setShowSaveModal] = useState<boolean>(false)
+  const toggleShowSaveModal = () => setShowSaveModal(!showSaveModal)
+
   const [canExport, setCanExport] = useState<boolean>(false)
   const [showExportModal, setShowExportModal] = useState<boolean>(false)
 
@@ -99,6 +106,7 @@ function ResultsCardFunction({
 
   useEffect(() => {
     setCanExport((result && !!result.deterministic) || false)
+    setCanSave((result && !!result.deterministic) || false)
   }, [result])
 
   return (
@@ -130,13 +138,22 @@ function ResultsCardFunction({
               <LinkButton
                 className="new-tab-button"
                 color="secondary"
-                desabled={!scenarioUrl}
+                disabled={!scenarioUrl}
                 href={scenarioUrl}
                 target="_blank"
                 data-testid="RunResultsInNewTab"
               >
                 {t('Run in new tab')}
               </LinkButton>
+              <Button
+                className="save-button"
+                type="button"
+                color="secondary"
+                disabled={!canSave}
+                onClick={(_) => setShowSaveModal(true)}
+              >
+                {t('Save')}
+              </Button>
               <ComparisonModalWithButton files={files} onFilesChange={handleFileSubmit} />
               <Button
                 className="export-button"
@@ -235,6 +252,7 @@ function ResultsCardFunction({
         canExport={canExport}
         result={result}
       />
+      <SaveSimulationDialog showModal={showSaveModal} toggleShowModal={toggleShowSaveModal} onSave={onSave} />
     </>
   )
 }

--- a/src/components/Main/Results/SaveSimulationDialog.tsx
+++ b/src/components/Main/Results/SaveSimulationDialog.tsx
@@ -1,0 +1,65 @@
+import React from 'react'
+import { Button, Modal, ModalBody, ModalFooter, ModalHeader, Table } from 'reactstrap'
+import { useTranslation } from 'react-i18next'
+import { AlgorithmResult } from '../../../algorithms/types/Result.types'
+import { Formik, FormikHelpers, Form } from 'formik'
+import * as Yup from 'yup'
+import { FormTextField } from '../../Form/FormTextField'
+
+export interface SaveSimulationDialogProps {
+  showModal: boolean
+  toggleShowModal: () => void
+  onSave: (name: string, creator: string) => void
+}
+
+interface SaveDetails {
+  name: string
+  owner: string
+}
+
+export default function SaveSimulationDialog({ showModal, toggleShowModal, onSave }: SaveSimulationDialogProps) {
+  const { t } = useTranslation()
+  const initValues: SaveDetails = {
+    name: '',
+    owner: '',
+  }
+
+  function handleSubmit(formValues: SaveDetails, { setSubmitting }: FormikHelpers<SaveDetails>) {
+    onSave(formValues.name, formValues.owner)
+  }
+
+  return (
+    <Modal className="height-fit" centered size="lg" isOpen={showModal} toggle={toggleShowModal}>
+      <ModalHeader toggle={toggleShowModal}>{'Save simulation'}</ModalHeader>
+      <ModalBody>
+        <Formik
+          initialValues={initValues}
+          onSubmit={(values) => {
+            onSave(values.name, values.owner)
+          }}
+          validationSchema={Yup.object().shape({
+            name: Yup.string().required('Required'),
+            owner: Yup.string().required('Required'),
+          })}
+        >
+          {({ errors, touched, isValid, isSubmitting }) => {
+            return (
+              <Form className="form">
+                <FormTextField identifier="name" label="Enter a scenario name" />
+                <FormTextField identifier="owner" label="Enter your name or email" />
+                <div className="modal-btn-container">
+                  <Button color="secondary" onClick={toggleShowModal}>
+                    Cancel
+                  </Button>
+                  <Button color="primary" type="submit" disabled={!isValid} onClick={toggleShowModal}>
+                    Save
+                  </Button>
+                </div>
+              </Form>
+            )
+          }}
+        </Formik>
+      </ModalBody>
+    </Modal>
+  )
+}

--- a/src/components/Main/ScenarioBoard/AdaptiveScenarioCard.tsx
+++ b/src/components/Main/ScenarioBoard/AdaptiveScenarioCard.tsx
@@ -1,0 +1,155 @@
+import React from 'react'
+import { AllParams } from '../../../algorithms/types/Param.types'
+import { AlgorithmResult } from '../../../algorithms/types/Result.types'
+import * as ACData from 'adaptivecards-templating'
+import * as AdaptiveCards from 'adaptivecards'
+
+const templatePayload = {
+  $schema: 'http://adaptivecards.io/schemas/adaptive-card.json',
+  type: 'AdaptiveCard',
+  version: '1.0',
+  body: [
+    {
+      type: 'Container',
+      items: [
+        {
+          type: 'TextBlock',
+          text: '{scenario.name}',
+          weight: 'bolder',
+          size: 'medium',
+        },
+        {
+          type: 'ColumnSet',
+          columns: [
+            {
+              type: 'Column',
+              width: 'auto',
+              items: [
+                {
+                  type: 'TextBlock',
+                  text: 'Created by',
+                  weight: 'bolder',
+                  wrap: true,
+                },
+                {
+                  type: 'TextBlock',
+                  text: 'Created on',
+                  weight: 'bolder',
+                  wrap: true,
+                },
+              ],
+            },
+            {
+              type: 'Column',
+              width: 'stretch',
+              items: [
+                {
+                  type: 'TextBlock',
+                  text: '{scenario.ownerEmail}',
+                  isSubtle: true,
+                  wrap: true,
+                },
+                {
+                  type: 'TextBlock',
+                  text: '{scenario.createdOn}',
+                  isSubtle: true,
+                  wrap: true,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  actions: [
+    {
+      type: 'Action.OpenUrl',
+      title: 'Clone',
+      url: '{scenario.url}',
+    },
+    {
+      type: 'Action.Submit',
+      title: 'Share',
+      url: '{scenario.url}',
+    },
+    {
+      type: 'Action.Submit',
+      title: 'Delete',
+    },
+  ],
+}
+
+export interface AdaptiveScenarioCardProps {
+  name: string
+  ownerEmail: string
+  createdOn: string
+  url: string
+  onDelete(name: string): void
+  onShare(url: string): void
+}
+
+function AdaptiveScenarioCard({ name, ownerEmail, createdOn, url, onDelete, onShare }: AdaptiveScenarioCardProps) {
+  // Create a Template instance from the template payload
+  const template = new ACData.Template(templatePayload)
+
+  // Create a data binding context, and set its $root property to the
+  // data object to bind the template to
+  const context = new ACData.EvaluationContext()
+  context.$root = {
+    scenario: {
+      name,
+      ownerEmail,
+      createdOn,
+      url,
+    },
+  }
+
+  // "Expand" the template - this generates the final payload for the Adaptive Card,
+  const payload = template.expand(context)
+
+  // Create an AdaptiveCard instance
+  const adaptiveCard = new AdaptiveCards.AdaptiveCard()
+
+  // configure action logic
+  adaptiveCard.onExecuteAction = (a: AdaptiveCards.Action) => {
+    if (a instanceof AdaptiveCards.OpenUrlAction) {
+      window.open(a.url, '_blank')
+    } else if (a instanceof AdaptiveCards.SubmitAction && a.title === 'Delete') {
+      onDelete(name)
+    } else if (a instanceof AdaptiveCards.SubmitAction && a.title === 'Share') {
+      onShare(url)
+    }
+  }
+
+  // Set its hostConfig property unless you want to use the default Host Config
+  // Host Config defines the style and behavior of a card
+  adaptiveCard.hostConfig = new AdaptiveCards.HostConfig({
+    fontFamily: 'Segoe UI, Helvetica Neue, sans-serif',
+    // More host config options
+  })
+
+  adaptiveCard.hostConfig.fontFamily = 'Segoe UI, Helvetica Neue, sans-serif'
+  adaptiveCard.hostConfig.containerStyles.default.backgroundColor = '#A0A6AB'
+
+  // Parse the card payload
+  adaptiveCard.parse(payload)
+
+  const result = adaptiveCard.render()
+  result.style.width = '300px'
+  result.style.margin = '20px'
+  return (
+    <div
+      ref={(n) => {
+        if (n && result) {
+          if (n.firstElementChild !== null) {
+            n.removeChild(n.firstElementChild)
+          }
+          n.appendChild(result)
+        }
+      }}
+    />
+  )
+}
+
+export { AdaptiveScenarioCard }

--- a/src/components/Main/ScenarioBoard/ScenarioBoard.tsx
+++ b/src/components/Main/ScenarioBoard/ScenarioBoard.tsx
@@ -1,0 +1,70 @@
+import React, { useState } from 'react'
+import { AdaptiveScenarioCard } from './AdaptiveScenarioCard'
+import LocalStorage, { LOCAL_STORAGE_KEYS } from '../../../helpers/localStorage'
+import { SavedScenario } from '../state/savedScenario'
+import { Link } from 'react-router-dom'
+import ShareScenarioDialog from './ShareScenarioDialog'
+
+export default function ScenarioBoard() {
+  // Read saved scenarios from local storage
+  let existingSavedScenarios = LocalStorage.get<SavedScenario[]>(LOCAL_STORAGE_KEYS.SAVED_SCENARIOS)
+
+  // if null, construct a new array
+  if (!existingSavedScenarios) {
+    existingSavedScenarios = []
+  }
+  const [savedScenarios, setSavedScenarios] = useState<SavedScenario[]>(existingSavedScenarios)
+
+  function onDeleteScenario(name: string) {
+    const filteredScenarios = savedScenarios.filter((sc) => sc.name !== name)
+    setSavedScenarios(filteredScenarios)
+    LocalStorage.set(LOCAL_STORAGE_KEYS.SAVED_SCENARIOS, filteredScenarios)
+  }
+
+  const [showShareModal, setShowShareModal] = useState<boolean>(false)
+  const [lastSharedScenario, setLastSharedScenario] = useState<string>('')
+  const toggleShowShareModal = () => setShowShareModal(!showShareModal)
+
+  function onShareScenario(url: string) {
+    setShowShareModal(true)
+    const hostUrl = window.location.host
+    setLastSharedScenario(hostUrl + url)
+  }
+
+  // iterate through the collection and render the cards
+  return savedScenarios.length > 0 ? (
+    <>
+      <div>
+        {savedScenarios.map((sc) => {
+          const creationTimeLocal: string = new Date(sc.creationTime).toLocaleString()
+          return (
+            <Link key={sc.name} to={sc.url}>
+              <AdaptiveScenarioCard
+                key={sc.name}
+                name={sc.name}
+                ownerEmail={sc.creator}
+                createdOn={creationTimeLocal}
+                url={sc.url}
+                onDelete={onDeleteScenario}
+                onShare={onShareScenario}
+              />
+            </Link>
+          )
+        })}
+      </div>
+      <ShareScenarioDialog
+        showModal={showShareModal}
+        toggleShowModal={toggleShowShareModal}
+        scenarioUrl={lastSharedScenario}
+      />
+    </>
+  ) : (
+    <div
+      style={{
+        textAlign: 'center',
+      }}
+    >
+      No saved scenarios
+    </div>
+  )
+}

--- a/src/components/Main/ScenarioBoard/ShareScenarioDialog.tsx
+++ b/src/components/Main/ScenarioBoard/ShareScenarioDialog.tsx
@@ -1,0 +1,55 @@
+import React, { useRef, useState } from 'react'
+import { Button, Modal, ModalBody, ModalFooter, ModalHeader, Table, Input } from 'reactstrap'
+import { useTranslation } from 'react-i18next'
+
+export interface ShareScenarioDialogProps {
+  showModal: boolean
+  toggleShowModal: () => void
+  scenarioUrl: string
+}
+
+export default function ShareScenarioDialog({ showModal, toggleShowModal, scenarioUrl }: ShareScenarioDialogProps) {
+  const { t } = useTranslation()
+
+  const [copyStatus, setCopyStatus] = useState('')
+
+  function copyToClipboard() {
+    if (document.queryCommandSupported('copy')) {
+      const textField = document.createElement('textarea')
+      textField.innerText = scenarioUrl
+      document.body.appendChild(textField)
+      textField.select()
+      document.execCommand('copy')
+      textField.remove()
+      setCopyStatus('Copied!')
+    } else {
+      setCopyStatus('Copy not supported in your browser!')
+    }
+  }
+
+  function resetCopyStatus() {
+    setCopyStatus('')
+  }
+
+  return (
+    <Modal
+      className="height-fit"
+      centered
+      size="lg"
+      isOpen={showModal}
+      toggle={toggleShowModal}
+      onClosed={resetCopyStatus}
+    >
+      <ModalHeader toggle={toggleShowModal}>{t('Share Scenario')}</ModalHeader>
+      <ModalBody>
+        <Input label="Url to share" value={scenarioUrl} />
+      </ModalBody>
+      <ModalFooter>
+        <Button color="primary" type="submit" onClick={copyToClipboard}>
+          Copy
+        </Button>
+        {copyStatus}
+      </ModalFooter>
+    </Modal>
+  )
+}

--- a/src/components/Main/state/savedScenario.ts
+++ b/src/components/Main/state/savedScenario.ts
@@ -1,0 +1,12 @@
+import { ScenarioData, EmpiricalData, AllParams } from '../../../algorithms/types/Param.types'
+import { AlgorithmResult } from '../../../algorithms/types/Result.types'
+import { SeverityTableRow } from '../Scenario/SeverityTable'
+import { string } from 'prop-types'
+import { defaultScenarioState } from './state'
+
+export interface SavedScenario {
+  name: string
+  creationTime: string
+  creator: string
+  url: string
+}

--- a/src/helpers/localStorage.ts
+++ b/src/helpers/localStorage.ts
@@ -5,6 +5,7 @@ export const LOCAL_STORAGE_KEYS = {
   SHOW_HUMANIZED_RESULTS: 'show-humanized-results',
   SUPPRESS_DISCLAIMER: 'suppress-disclaimer',
   SKIP_LANDING_PAGE: 'skip-landing-page',
+  SAVED_SCENARIOS: 'saved-scenarios',
 } as const
 
 export type LocalStorageKey = typeof LOCAL_STORAGE_KEYS[keyof typeof LOCAL_STORAGE_KEYS]

--- a/src/links.ts
+++ b/src/links.ts
@@ -1,7 +1,8 @@
 import i18next from 'i18next'
 
 const links = {
-  '/': 'COVID-19 Scenarios',
+  '/': 'Home',
+  '/saved': 'Saved Scenarios',
   '/about': i18next.t('About'),
   '/acknowledgements': i18next.t('Acknowledgements'),
   '/faq': i18next.t('FAQ'),

--- a/src/pages/SavedScenarios.tsx
+++ b/src/pages/SavedScenarios.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import { Container, Col, Row } from 'reactstrap'
+
+import LinkExternal from '../components/Router/LinkExternal'
+import ScenarioBoard from '../components/Main/ScenarioBoard/ScenarioBoard'
+
+const SavedScenarios: React.FC = () => {
+  return (
+    <Container>
+      <ScenarioBoard />
+    </Container>
+  )
+}
+
+export default SavedScenarios

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -2,6 +2,7 @@ import { PageRouteDesc } from './components/PageSwitcher/PageSwitcher'
 
 const routes: PageRouteDesc[] = [
   { path: '/', page: 'Home' },
+  { path: '/saved', page: 'SavedScenarios' },
   { path: '/about', page: 'About' },
   { path: '/acknowledgements', page: 'Acknowledgements' },
   { path: '/faq', page: 'Faq' },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2886,6 +2886,16 @@ acorn@^7.1.0, acorn@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.1.tgz#e35668de0b402f359de515c5482a1ab9f89a69bf"
   integrity sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==
 
+adaptivecards-templating@0.1.1-alpha.1:
+  version "0.1.1-alpha.1"
+  resolved "https://registry.yarnpkg.com/adaptivecards-templating/-/adaptivecards-templating-0.1.1-alpha.1.tgz#e7b77d70a29f154b9bcf64a0d61707671ca1c654"
+  integrity sha512-pK34y5tcqmtcUZaaEK1EgrTLJX8yq6RYc2hp3x/IsLdDZm6pFGWliYD8pAQnJdyvblpxV82XTnAMhnBw0HUi7A==
+
+adaptivecards@1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/adaptivecards/-/adaptivecards-1.2.5.tgz#221253df88c07b828b41d0caff01c5bd80dd235d"
+  integrity sha512-Rj+QK0qtBOfLGy3ClXylKxL4ze/a6mtPiJL7Ctjyc1Uso9O1x/LAAu49F36ZQbgAa8vWkKW91RKcwBBOxk3HDg==
+
 address@1.1.2, address@^1.0.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/address/-/address-1.1.2.tgz#bf1116c9c758c51b7a933d296b72c221ed9428b6"


### PR DESCRIPTION
## Related issues and PRs
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->
 - Related to #181 

## Description
Introduced a new button 'Save' in the results view. 
![image](https://user-images.githubusercontent.com/8034623/78514147-b710fc00-7764-11ea-8b4a-7e80f21d2ec1.png)

When the user clicks 'Save', a modal will appear for the user to enter a name for the scenario and his email or name. Upon saving, the scenario will be saved locally with the (name/owner/creationTime/Url). Here the URL is same as the serialized query string constructed upon 'Run'. 
![image](https://user-images.githubusercontent.com/8034623/78514063-508bde00-7764-11ea-8d03-8ef51df5977a.png)

Introduced a new page 'Saved Scenarios' where all saved scenarios are shown as [Adaptive Cards](https://docs.microsoft.com/en-us/adaptive-cards/sdk/rendering-cards/javascript/render-a-card). When the card is clicked, there will be page redirect to home using the URL from the deserialized scenario. In addition to this, there will be three actions in each card. 
![image](https://user-images.githubusercontent.com/8034623/78514033-26d2b700-7764-11ea-87b5-757d9264ec17.png)

Share - will open a modal with the scenario URL that can be copied to the clipboard using the 'Copy button'
![image](https://user-images.githubusercontent.com/8034623/78514047-39e58700-7764-11ea-8d18-81a148370537.png)

Clone - will open the scenario in a new tab (need some input on this behavior)
Delete - will delete the scenario from local storage and re-renders the board.

Pending work:

- [ ] Display the scenario name (and possibly other details like owner) when the adaptive card is clicked
- [ ] Confirm delete action
- [ ] After clicking 'Save' and save is successful, let the user know that the save is successful
- [ ] Use an URL shortening service inside 'Share'
- [ ] CSS fixes
- [ ] Use translation

## Impacted Areas in the application
<!-- Components of the application that this PR will change -->
Main page will show a new button to Save
New page added - Saved Scenarios

## Testing
<!-- Steps to test the changes proposed by this PR -->
- Click on save after a scenario run
- Open 'Saved scenarios' to view saved scenarios
- Perform the actions like 'Share/Delete/Clone' or click the card to view the scenario
