### PR TITLE
Styling Mitigation Intervals

### DIFF
--- a/src/components/Main/Mitigation/MitigationDatePicker.tsx
+++ b/src/components/Main/Mitigation/MitigationDatePicker.tsx
@@ -24,7 +24,7 @@ export interface MitigationDatePickerProps {
 
 export function MitigationDatePicker({ identifier, value, allowPast = true }: MitigationDatePickerProps) {
   return (
-    <FastField name={identifier}>
+    <FastField name={identifier} className="date-picker form-control">
       {({ form: { setFieldValue } }: FieldProps<DateRange>) => {
         return (
           <Media

--- a/src/components/Main/Mitigation/MitigationTable.scss
+++ b/src/components/Main/Mitigation/MitigationTable.scss
@@ -1,7 +1,62 @@
 @import '../../../styles/variables';
 
-.form-group.interval-form-group {
+.mitigation-table .form-group {
   border: $gray-500 solid 1px;
   padding: 4px 2px;
   margin-bottom: 10px;
+}
+
+.mitigation-interval {
+  display: flex;
+  width: 100%;
+}
+
+.mitigation-interval > .inputs {
+  display: flex;
+  flex-grow: 1;
+}
+
+.mitigation-interval.narrow > .inputs,
+.mitigation-interval.very-narrow > .inputs {
+  flex-direction: column;
+}
+
+.mitigation-interval > .inputs > * {
+  flex-grow: 1;
+}
+
+.mitigation-interval > .inputs > .item-date-range-value-group {
+  display: flex;
+}
+
+.mitigation-interval.wide .DateRangePickerInput,
+.mitigation-interval.narrow .DateRangePickerInput {
+  // stop the date range from wrapping the dates.
+  // but not for very narrow views where it would cause overflow.
+  width: max-content;
+}
+
+.mitigation-interval > .inputs > .item-date-range-value-group > .item-value {
+  width: auto;
+}
+
+.mitigation-interval .DateInput_input {
+  // make the date range input similar to bootstrap inputs
+  height: calc(1.5em + 0.75rem + 1px);
+}
+
+.mitigation-interval > *:not(:last-child),
+.mitigation-interval.wide > .inputs > :not(:last-child),
+.mitigation-interval > .inputs > .item-date-range-value-group > :not(:last-child) {
+  margin-right: 4px;
+}
+
+.mitigation-interval.narrow > .inputs > :not(:last-child),
+.mitigation-interval.very-narrow > .inputs > :not(:last-child) {
+  margin-bottom: 4px;
+}
+
+.mitigation-table .table-controls {
+  display: flex;
+  justify-content: flex-end;
 }

--- a/src/components/Main/Mitigation/MitigationTable.tsx
+++ b/src/components/Main/Mitigation/MitigationTable.tsx
@@ -1,10 +1,11 @@
 import React from 'react'
+import ReactResizeDetector from 'react-resize-detector'
 
-import { FastField, FieldArray } from 'formik'
+import { FastField, FieldArray, FieldArrayRenderProps } from 'formik'
 import { useTranslation } from 'react-i18next'
-import { Button, FormGroup, Row, Col } from 'reactstrap'
+import { Button, FormGroup } from 'reactstrap'
 
-import { FaTrash } from 'react-icons/fa'
+import { FaTrash, FaPlus } from 'react-icons/fa'
 
 import { MitigationInterval, MitigationIntervals } from '../../../algorithms/types/Param.types'
 
@@ -22,55 +23,29 @@ export function MitigationTable({ mitigationIntervals }: MitigationTableProps) {
   const { t } = useTranslation()
 
   return (
-    <FieldArray
-      name="containment.mitigationIntervals"
-      render={(arrayHelpers) => (
-        <Row noGutters>
-          <Col>
-            <Row>
-              <Col>
-                <div className="form-inline w-100">
-                  {mitigationIntervals.map((interval: MitigationInterval, index: number) => {
-                    if (!interval) {
-                      return null
-                    }
-
-                    return (
-                      <FormGroup key={interval.id} className="interval-form-group w-100">
-                        <FastField
-                          className="form-control"
-                          id={`containment.mitigationIntervals[${index}].name`}
-                          name={`containment.mitigationIntervals[${index}].name`}
-                          type="text"
-                        />
-
-                        <MitigationDatePicker
-                          identifier={`containment.mitigationIntervals[${index}].timeRange`}
-                          value={interval.timeRange}
-                          allowPast
-                        />
-
-                        <FastField
-                          className="form-control"
-                          id={`containment.mitigationIntervals[${index}].mitigationValue`}
-                          name={`containment.mitigationIntervals[${index}].mitigationValue`}
-                          type="number"
-                          step={0.1}
-                          min={0}
-                          max={1}
-                        />
-
-                        <Button type="button" onClick={() => arrayHelpers.remove(index)}>
-                          <FaTrash />
-                        </Button>
-                      </FormGroup>
-                    )
-                  })}
-                </div>
-              </Col>
-            </Row>
-            <Row>
-              <Col>
+    <ReactResizeDetector handleWidth>
+      {({ width }: { width?: number }) => (
+        <FieldArray
+          name="containment.mitigationIntervals"
+          render={(arrayHelpers) => (
+            <div className="mitigation-table">
+              <div className="w-100">
+                {mitigationIntervals.map((interval: MitigationInterval, index: number) => {
+                  if (!interval) {
+                    return null
+                  }
+                  return (
+                    <MitigationIntervalComponent
+                      key={interval.id}
+                      interval={interval}
+                      index={index}
+                      arrayHelpers={arrayHelpers}
+                      width={width || 0}
+                    />
+                  )
+                })}
+              </div>
+              <div className="table-controls">
                 <Button
                   type="button"
                   onClick={() => {
@@ -78,13 +53,65 @@ export function MitigationTable({ mitigationIntervals }: MitigationTableProps) {
                     arrayHelpers.push(interval)
                   }}
                 >
-                  {t('Add')}
+                  {t('Add')} <FaPlus />
                 </Button>
-              </Col>
-            </Row>
-          </Col>
-        </Row>
+              </div>
+            </div>
+          )}
+        />
       )}
-    />
+    </ReactResizeDetector>
+  )
+}
+
+interface MitigationIntervalProps {
+  width: number
+  index: number
+  interval: MitigationInterval
+  arrayHelpers: FieldArrayRenderProps
+}
+
+function MitigationIntervalComponent({ width, index, interval, arrayHelpers }: MitigationIntervalProps) {
+  const { t } = useTranslation()
+
+  return (
+    <FormGroup>
+      <div
+        className={`mitigation-interval ${
+          // eslint-disable-next-line unicorn/no-nested-ternary
+          width && width <= 325 ? 'very-narrow' : width && width <= 580 ? 'narrow' : 'wide'
+        }`}
+      >
+        <div className="inputs">
+          <FastField
+            className="name form-control"
+            id={`containment.mitigationIntervals[${index}].name`}
+            name={`containment.mitigationIntervals[${index}].name`}
+            type="text"
+          />
+          <div className="item-date-range-value-group">
+            <MitigationDatePicker
+              identifier={`containment.mitigationIntervals[${index}].timeRange`}
+              value={interval.timeRange}
+              allowPast
+            />
+            <FastField
+              className="form-control item-value"
+              id={`containment.mitigationIntervals[${index}].mitigationValue`}
+              name={`containment.mitigationIntervals[${index}].mitigationValue`}
+              type="number"
+              step={0.1}
+              min={0}
+              max={1}
+            />
+          </div>
+        </div>
+        <div className="item-controls">
+          <Button type="button" onClick={() => arrayHelpers.remove(index)}>
+            {width && width > 430 && t('Remove')} <FaTrash />
+          </Button>
+        </div>
+      </div>
+    </FormGroup>
   )
 }

--- a/src/components/TestStandalone/MitigationTableTest.tsx
+++ b/src/components/TestStandalone/MitigationTableTest.tsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+import { Formik } from 'formik'
+
+import { CardWithoutDropdown } from '../Form/CardWithoutDropdown'
+import { MitigationTable } from '../Main/Mitigation/MitigationTable'
+import { MitigationIntervals } from '../../algorithms/types/Param.types'
+
+function MitigationTableTest() {
+  const { t } = useTranslation()
+
+  const mitigationIntervals: MitigationIntervals = [
+    {
+      color: '#bf5b17',
+      id: '06ad1640-ce01-41c0-8dc2-78fbbfbd8dd6',
+      mitigationValue: 0.2,
+      name: 'Intervention #1',
+      timeRange: {
+        tMax: new Date('2020-09-01'),
+        tMin: new Date('2020-03-12'),
+      },
+    },
+    {
+      color: '#666666',
+      id: 'a353e47f-ed52-4517-9cb5-063878edbbca',
+      mitigationValue: 0.6,
+      name: 'Intervention #2',
+      timeRange: {
+        tMax: new Date('2020-09-01'),
+        tMin: new Date('2020-03-29'),
+      },
+    },
+  ]
+
+  return (
+    <CardWithoutDropdown
+      identifier="containmentScenario"
+      label={<h3 className="p-0 d-inline text-truncate">{t('Mitigation')}</h3>}
+      help={t('Reduction of transmission through mitigation measures over time. Add or remove interventions.')}
+    >
+      <div className="w-auto">
+        <Formik enableReinitialize initialValues={{ containment: { mitigationIntervals } }} onSubmit={() => null}>
+          <MitigationTable mitigationIntervals={mitigationIntervals} />
+        </Formik>
+      </div>
+    </CardWithoutDropdown>
+  )
+}
+
+export default MitigationTableTest

--- a/src/pages/TestStandalone.tsx
+++ b/src/pages/TestStandalone.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+import TheTest from '../components/TestStandalone/MitigationTableTest'
+
+function TestStandalone() {
+  return <TheTest />
+}
+
+export default TestStandalone

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -8,4 +8,8 @@ const routes: PageRouteDesc[] = [
   { path: '/updates', page: 'Updates' },
 ]
 
+if (process.env.NODE_ENV !== 'production') {
+  routes.push({ path: '/test_standalone', page: 'TestStandalone' })
+}
+
 export default routes


### PR DESCRIPTION
## Related issues and PRs

Fixes #383 

## Description

Provides a reasonable view of the mitigation form from very narrow through wide. Uses the width of the widget rather than media queries. Includes a standalone component test view route (only present when not production).

## Impacted Areas in the application

Mitigation interval input.

## Testing

Wide -> Narrow & back.
Add & delete.
