### PR TITLE
undo draggable grid layout -- causes problems on mobile and little be…

### DIFF
--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -6,7 +6,6 @@ import _ from 'lodash'
 import { Form, Formik, FormikHelpers } from 'formik'
 
 import { Col, Row } from 'reactstrap'
-import { Responsive, WidthProvider, Layout } from 'react-grid-layout'
 
 import { SeverityTableRow } from './Scenario/SeverityTable'
 
@@ -78,8 +77,6 @@ const severityDefaults: SeverityTableRow[] = updateSeverityTable(severityData)
 const isRegion = (region: string): region is keyof typeof countryCaseCountData => {
   return Object.prototype.hasOwnProperty.call(countryCaseCountData, region)
 }
-
-const ResponsiveGridLayout = WidthProvider(Responsive)
 
 function Main() {
   const [result, setResult] = useState<AlgorithmResult | undefined>()
@@ -174,18 +171,6 @@ function Main() {
     setSubmitting(false)
   }
 
-  const resultsCardX: any = { lg: 6, md: 6, sm: 0, xs: 0, xxs: 0 }
-  const [resultLayout, setResultLayout] = useState({ x: 6, y: 0, w: 6, h: 12 })
-  const [layouts, setLayouts] = useState({})
-
-  const onBreakpointChange = (breakpoint: string) => {
-    setResultLayout({ ...resultLayout, x: resultsCardX[breakpoint] })
-  }
-
-  const onLayoutChange = (currentLayout: Layout, allLayouts: any) => {
-    setLayouts(allLayouts)
-  }
-
   return (
     <Row>
       <Col md={12}>
@@ -201,16 +186,8 @@ function Main() {
 
             return (
               <Form className="form">
-                <ResponsiveGridLayout
-                  preventCollision={true}
-                  draggableHandle=".card-header"
-                  layouts={layouts}
-                  breakpoints={{ lg: 1200, md: 996, sm: 768, xs: 480, xxs: 0 }}
-                  cols={{ lg: 12, md: 12, sm: 6, xs: 6, xxs: 6 }}
-                  onBreakpointChange={onBreakpointChange}
-                  onLayoutChange={onLayoutChange}
-                >
-                  <div key="0" data-grid={{ x: 0, y: 0, w: 6, h: 12 }}>
+                <Row>
+                  <Col lg={4} xl={6} className="py-1">
                     <ScenarioCard
                       severity={severity}
                       setSeverity={setSeverity}
@@ -219,8 +196,9 @@ function Main() {
                       errors={errors}
                       touched={touched}
                     />
-                  </div>
-                  <div key="1" data-grid={resultLayout}>
+                  </Col>
+
+                  <Col lg={8} xl={6} className="py-1">
                     <ResultsCard
                       canRun={canRun}
                       autorunSimulation={autorunSimulation}
@@ -232,8 +210,8 @@ function Main() {
                       caseCounts={empiricalCases}
                       scenarioUrl={scenarioUrl}
                     />
-                  </div>
-                </ResponsiveGridLayout>
+                  </Col>
+                </Row>
               </Form>
             )
           }}


### PR DESCRIPTION
…nefit on desktop


## Description
as @ivan-aksamentov points out, the draggable layout doesn't work on mobile and is of little benefit on desktop. This PR reverts the changes bu @guandiyiyi in Main.tsx, but keeps the changes in the plot. 

## Impacted Areas in the application
Main is back to the state of previous master at 97a742150e1ede288894a594204d21df0db00042

There are still left-overs from react-grid-layout in the css and the package.json

## Testing

