### PR TITLE
SyntaxError fix when running yarn dev, Windows 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "scripts": {
     "clear": "node lib/clear.js",
-    "schema:totypes": "yarn babel-node --extensions '.ts' tools/convertSchemasToType.ts",
+    "schema:totypes": "yarn babel-node --extensions \".ts\" tools/convertSchemasToType.ts",
     "schema:clean": "rimraf 'src/.generated/{*,.*}' 'data/generated_types/{*,.*}'",
     "dev": "nodemon --config config/nodemon/dev.json",
     "dev:start": "yarn install && yarn schema:totypes && yarn dev:nowatch || cd .",


### PR DESCRIPTION
## Related issues and PRs
#450 

## Description
Was unable to run application using Windows 10 without getting Syntaxerror. Added backslashes to escape quotation marks in line 9 in package.json.

## Impacted Areas in the application
Package.json
