### PR TITLE
Center spinner

### DIFF
--- a/src/pages/Loading.scss
+++ b/src/pages/Loading.scss
@@ -1,5 +1,5 @@
 .loading-page {
-  margin-top: 1rem;
+  margin-top: 25%;
 
   > div.spinner-border {
     width: 6rem;


### PR DESCRIPTION
## Related issues and PRs
#442 
 - 

## Description
Move spinner farther down page. Set margin-top property in spinner container to 25%. Recommend testing with different browsers and sizes to make sure desired effect is achieved.

## Impacted Areas in the application
Loading.scss

## Testing
Open main simulator page. Refresh page to view spinner.
