### PR TITLE
Apply viewport height to spinner style

### DIFF
--- a/src/pages/Loading.scss
+++ b/src/pages/Loading.scss
@@ -1,6 +1,6 @@
 .loading-page {
-  margin-top: 25%;
-
+  margin-top: calc((100vh - 6rem)/2);
+  
   > div.spinner-border {
     width: 6rem;
     height: 6rem;


### PR DESCRIPTION
## Related issues and PRs
#442 
 - 

## Description
Change margin-top value in spinner to use viewport height instead of straight percentage. Should achieve better centering.

## Impacted Areas in the application
Loading.scss

## Testing
Refresh main page to see spinner.