### PR TITLE
#475/Fix race condition between two validation methods.

### DIFF
--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -133,7 +133,7 @@ function Main() {
     }
   }, [autorunSimulation, debouncedRun, scenarioState, locationSearch, severity])
 
-  const [setScenarioToCustom] = useDebouncedCallback((newParams: AllParams) => {
+  const setScenarioToCustom = (newParams: AllParams) => {
     // NOTE: deep object comparison!
     if (!_.isEqual(allParams.population, newParams.population)) {
       scenarioDispatch(setPopulationData({ data: newParams.population }))
@@ -151,7 +151,7 @@ function Main() {
       const mitigationIntervals = _.map(newParams.containment.mitigationIntervals, _.cloneDeep)
       scenarioDispatch(setContainmentData({ data: { mitigationIntervals } }))
     }
-  }, 1000)
+  }
 
   function handleSubmit(params: AllParams, { setSubmitting }: FormikHelpers<AllParams>) {
     updateBrowserURL(locationSearch)
@@ -167,10 +167,13 @@ function Main() {
           initialValues={allParams}
           validationSchema={schema}
           onSubmit={handleSubmit}
-          validate={setScenarioToCustom}
         >
           {({ values, errors, touched, isValid, isSubmitting }) => {
             const canRun = isValid && severityTableIsValid(severity)
+
+            if (isValid) {
+              setScenarioToCustom(values)
+            }
 
             return (
               <Form className="form">

--- a/src/components/Main/Results/DeterministicLinePlot.tsx
+++ b/src/components/Main/Results/DeterministicLinePlot.tsx
@@ -97,6 +97,22 @@ function legendFormatter(enabledPlots: string[], value: string, entry: any) {
   return <span className={activeClassName}>{value}</span>
 }
 
+export class DebouncedDeterministicLinePlot extends React.Component {
+  constructor(props) {
+    super(props)
+    this.debouncedRender = _.debounce(this.forceUpdate, 1000)
+  }
+
+  shouldComponentUpdate() {
+    this.debouncedRender()
+    return false
+  }
+
+  render() {
+    return <DeterministicLinePlot {...this.props} />
+  }
+}
+
 export function DeterministicLinePlot({
   data,
   userResult,

--- a/src/components/Main/Results/ResultsCard.tsx
+++ b/src/components/Main/Results/ResultsCard.tsx
@@ -10,7 +10,7 @@ import { AgeBarChart } from './AgeBarChart'
 import { AlgorithmResult, UserResult } from '../../../algorithms/types/Result.types'
 import { CollapsibleCard } from '../../Form/CollapsibleCard'
 import { ComparisonModalWithButton } from '../Compare/ComparisonModalWithButton'
-import { DeterministicLinePlot } from './DeterministicLinePlot'
+import { DebouncedDeterministicLinePlot } from './DeterministicLinePlot'
 import { AllParams, ContainmentData, EmpiricalData } from '../../../algorithms/types/Param.types'
 import { FileType } from '../Compare/FileUploadZone'
 import { OutcomeRatesTable } from './OutcomeRatesTable'
@@ -191,7 +191,7 @@ function ResultsCardFunction({
         </Row>
         <Row noGutters>
           <Col>
-            <DeterministicLinePlot
+            <DebouncedDeterministicLinePlot
               data={result}
               userResult={userResult}
               params={params}


### PR DESCRIPTION
## Related issues and PRs

Fixes #475 

## Description

Form validation sometimes works, sometimes doesn't. The bug is due to a combination of issues.

Briefly: two Formik validation methods are used by the app: 'validate' and 'schema`. The schema compares the AllParams structure to a Yup schema. That works fine. The second validation method is used concurrently but not actually used to validate the data. It (potentially) modifies the values used by the form in order to set the scenario state, and always returns no error because it is not really a validator.

This is a WIP to the behavior.

## Impacted Areas in the application

Form validation.

## Testing

In progress.
