### PR TITLE
#461/Remove autoupdating scenarioURL.

### DIFF
--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -139,7 +139,6 @@ function Main() {
   }, 1000)
 
   function handleSubmit(params: AllParams, { setSubmitting }: FormikHelpers<AllParams>) {
-    updateBrowserURL(locationSearch)
     runSimulation(params, scenarioState, severity, setResult, setEmpiricalCases)
     setSubmitting(false)
   }

--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -79,7 +79,6 @@ function Main() {
   // TODO: Can this complex state be handled by formik too?
   const [severity, setSeverity] = useState<SeverityTableRow[]>(severityDefaults)
   const [locationSearch, setLocationSeach] = useState<string>('')
-  const scenarioUrl = `${window.location.origin}${locationSearch}`
 
   const [empiricalCases, setEmpiricalCases] = useState<EmpiricalData | undefined>()
 
@@ -117,21 +116,7 @@ function Main() {
     if (autorunSimulation) {
       debouncedRun(allParams, scenarioState, severity)
     }
-
-    // 1. upon each parameter change, we rebuild the query string
-    const nextLocationSearch = buildLocationSearch(scenarioState)
-
-    if (nextLocationSearch !== locationSearch) {
-      // whenever the generated query string changes, we're updating:
-      // 1. browser's location.search
-      // 2. searchString state variable (scenarioUrl is used by children)
-      setLocationSeach(nextLocationSearch)
-
-      if (autorunSimulation) {
-        updateBrowserURL(nextLocationSearch)
-      }
-    }
-  }, [autorunSimulation, debouncedRun, scenarioState, locationSearch, severity])
+  }, [autorunSimulation, debouncedRun, scenarioState, severity])
 
   const [setScenarioToCustom] = useDebouncedCallback((newParams: AllParams) => {
     // NOTE: deep object comparison!
@@ -197,7 +182,6 @@ function Main() {
                       mitigation={allParams.containment}
                       result={result}
                       caseCounts={empiricalCases}
-                      scenarioUrl={scenarioUrl}
                     />
                   </Col>
                 </Row>

--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -184,6 +184,7 @@ function Main() {
                       mitigation={allParams.containment}
                       result={result}
                       caseCounts={empiricalCases}
+                      getScenarioUrl={() => buildLocationSearch(scenarioState)}
                     />
                   </Col>
                 </Row>

--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -105,7 +105,7 @@ function Main() {
       debouncedRun(allParams, scenarioState, severity)
 
       // At this point the scenario params have been captured, and we can clean up the URL.
-      updateBrowserURL("/")
+      updateBrowserURL('/')
     }
   }, [])
 

--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -184,7 +184,7 @@ function Main() {
                       mitigation={allParams.containment}
                       result={result}
                       caseCounts={empiricalCases}
-                      getScenarioUrl={() => buildLocationSearch(scenarioState)}
+                      scenarioUrl={buildLocationSearch(scenarioState)}
                     />
                   </Col>
                 </Row>

--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -103,6 +103,9 @@ function Main() {
     // this is because the page was either shared via link, or opened in new tab
     if (window.location.search) {
       debouncedRun(allParams, scenarioState, severity)
+
+      // At this point the scenario params have been captured, and we can clean up the URL.
+      updateBrowserURL("/")
     }
   }, [])
 

--- a/src/components/Main/Results/ResultsCard.tsx
+++ b/src/components/Main/Results/ResultsCard.tsx
@@ -31,6 +31,7 @@ interface ResultsCardProps {
   severity: SeverityTableRow[] // TODO: pass severity throughout the algorithm and as a part of `AlgorithmResult` instead?
   result?: AlgorithmResult
   caseCounts?: EmpiricalData
+  getScenarioUrl: () => string
 }
 
 function ResultsCardFunction({
@@ -42,12 +43,11 @@ function ResultsCardFunction({
   severity,
   result,
   caseCounts,
+  getScenarioUrl,
 }: ResultsCardProps) {
   const { t } = useTranslation()
   const [logScale, setLogScale] = useState(LOG_SCALE_DEFAULT)
   const [showHumanized, setShowHumanized] = useState(SHOW_HUMANIZED_DEFAULT)
-
-  const scenarioUrl = undefined; // TODO build scenarioURL when needed.
 
   // TODO: shis should probably go into the `Compare/`
   const [files, setFiles] = useState<Map<FileType, File>>(new Map())
@@ -131,8 +131,7 @@ function ResultsCardFunction({
               <LinkButton
                 className="new-tab-button"
                 color="secondary"
-                disabled={!scenarioUrl}
-                href={scenarioUrl}
+                href={getScenarioUrl()}
                 target="_blank"
                 data-testid="RunResultsInNewTab"
               >

--- a/src/components/Main/Results/ResultsCard.tsx
+++ b/src/components/Main/Results/ResultsCard.tsx
@@ -131,6 +131,7 @@ function ResultsCardFunction({
               <LinkButton
                 className="new-tab-button"
                 color="secondary"
+                disabled={!canRun}
                 href={getScenarioUrl()}
                 target="_blank"
                 data-testid="RunResultsInNewTab"

--- a/src/components/Main/Results/ResultsCard.tsx
+++ b/src/components/Main/Results/ResultsCard.tsx
@@ -31,7 +31,7 @@ interface ResultsCardProps {
   severity: SeverityTableRow[] // TODO: pass severity throughout the algorithm and as a part of `AlgorithmResult` instead?
   result?: AlgorithmResult
   caseCounts?: EmpiricalData
-  getScenarioUrl: () => string
+  scenarioUrl: string
 }
 
 function ResultsCardFunction({
@@ -43,7 +43,7 @@ function ResultsCardFunction({
   severity,
   result,
   caseCounts,
-  getScenarioUrl,
+  scenarioUrl,
 }: ResultsCardProps) {
   const { t } = useTranslation()
   const [logScale, setLogScale] = useState(LOG_SCALE_DEFAULT)
@@ -132,7 +132,7 @@ function ResultsCardFunction({
                 className="new-tab-button"
                 color="secondary"
                 disabled={!canRun}
-                href={getScenarioUrl()}
+                href={scenarioUrl}
                 target="_blank"
                 data-testid="RunResultsInNewTab"
               >

--- a/src/components/Main/Results/ResultsCard.tsx
+++ b/src/components/Main/Results/ResultsCard.tsx
@@ -31,7 +31,6 @@ interface ResultsCardProps {
   severity: SeverityTableRow[] // TODO: pass severity throughout the algorithm and as a part of `AlgorithmResult` instead?
   result?: AlgorithmResult
   caseCounts?: EmpiricalData
-  scenarioUrl?: string
 }
 
 function ResultsCardFunction({
@@ -43,11 +42,12 @@ function ResultsCardFunction({
   severity,
   result,
   caseCounts,
-  scenarioUrl,
 }: ResultsCardProps) {
   const { t } = useTranslation()
   const [logScale, setLogScale] = useState(LOG_SCALE_DEFAULT)
   const [showHumanized, setShowHumanized] = useState(SHOW_HUMANIZED_DEFAULT)
+
+  const scenarioUrl = undefined; // TODO build scenarioURL when needed.
 
   // TODO: shis should probably go into the `Compare/`
   const [files, setFiles] = useState<Map<FileType, File>>(new Map())


### PR DESCRIPTION
## Related issues and PRs

Contribtutes to #461, but does not implement 'sharing' feature. 

## Description

This remove auto-generation of the URL parameters.

WIP:

- ~~App needs to parse URL if present, and apply to scenario params.~~
- ~~Run in new tab needs to generate URL before opening window.~~
- ~~Run in new tab should be disabled if simulation cannot be run~~

## Impacted Areas in the application

Browser URL should be clean, no longer polluted by URL params.
"Run in tab" internal logic has changed, but should look unchanged to the user.

## Testing

1. Open a fresh browser session
 - Confirm there are no url params, i.e. URL should simply be `http://for.example.com/`
2. Change some scenario parameters.
 - Confirm there are no url params.
3. Run the scenario.
 - Confirm there are no url params.
4. "Run in new tab"
 - A new tab should open, and the simulation should be run.
 - The new tab should have no url params (they may flash momentarily, then be cleared away.)

