### PR TITLE
#475/Validate before state update

### DIFF
--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -3,7 +3,7 @@ import { useDebouncedCallback } from 'use-debounce'
 
 import _ from 'lodash'
 
-import { Form, Formik, FormikHelpers, FormikErrors } from 'formik'
+import { Form, Formik, FormikHelpers, FormikErrors, FormikValues } from 'formik'
 
 import { Col, Row } from 'reactstrap'
 
@@ -32,6 +32,10 @@ import { updateSeverityTable } from './Scenario/severityTableUpdate'
 import { TimeSeries } from '../../algorithms/types/TimeSeries.types'
 
 import './Main.scss'
+
+interface FormikValidationErrors extends Error {
+  errors: FormikErrors<FormikValues>
+}
 
 export function severityTableIsValid(severity: SeverityTableRow[]) {
   return !severity.some((row) => _.values(row?.errors).some((x) => x !== undefined))
@@ -157,7 +161,7 @@ function Main() {
 
         return validParams
       })
-      .catch((err: Error) => err.errors)
+      .catch((error: FormikValidationErrors) => error.errors)
   }, 1000)
 
   function handleSubmit(params: AllParams, { setSubmitting }: FormikHelpers<AllParams>) {
@@ -172,9 +176,9 @@ function Main() {
         <Formik
           enableReinitialize
           initialValues={allParams}
-          validationSchema={schema}
           onSubmit={handleSubmit}
           validate={validateFormAndUpdateState}
+          validationSchema={schema}
         >
           {({ values, errors, touched, isValid, isSubmitting }) => {
             const canRun = isValid && severityTableIsValid(severity)


### PR DESCRIPTION
## Related issues and PRs

Fixes #475 

## Description

The App uses Formik's validate method to trigger autorun. However it does not validate the date. And so the state used to run() is possibly invalid. 

This change uses the yup schema to validate the parameters and only updates state if they pass.

## Notes:

1. Mitigation table does not display validation errors. Perhaps that is fixed in #454 
2. There is double validation input to Formik. However removing `validationSchema=` disables validation. Possibly this is due to the debounced nature of `validate=`. 

## Impacted Areas in the application

Form validation
Auto run

## Testing

```
with URL ingestion/update disabled

clear localStorage
load /
Set latency = -1
Focus out of input
=> Should be non-negative error displayed
Run is disabled
PASS

Enable auto run
run() is not triggered
PASS

Set latency = 4
run() is triggered with latency = 4
PASS
```

