### PR TITLE
Fix Export sharable URL

### DIFF
--- a/src/components/Main/Results/ExportSimulationDialog.tsx
+++ b/src/components/Main/Results/ExportSimulationDialog.tsx
@@ -10,10 +10,14 @@ export interface ExportSimulationDialogProps {
   showModal: boolean
   toggleShowModal: () => void
   result?: AlgorithmResult
+  scenarioUrl: string
 }
 
-export default function ExportSimulationDialog({ showModal, toggleShowModal, result }: ExportSimulationDialogProps) {
+export default function ExportSimulationDialog({ showModal, toggleShowModal, result, scenarioUrl }: ExportSimulationDialogProps) {
   const { t } = useTranslation()
+
+  // Assuming href and shareable link can be concatenated without other processing:
+  const shareableLink = `${window.location.href}${scenarioUrl}`
 
   return (
     <Modal className="height-fit" centered size="lg" isOpen={showModal} toggle={toggleShowModal}>
@@ -64,7 +68,7 @@ export default function ExportSimulationDialog({ showModal, toggleShowModal, res
               <td>{t('Shareable link')}</td>
               <td>URL</td>
               <td>
-                <ClipboardButton disabled={!(result?.params ?? null)} textToCopy={window.location.href}>
+                <ClipboardButton disabled={!(result?.params ?? null)} textToCopy={shareableLink}>
                   {t('Copy link')}
                 </ClipboardButton>
               </td>

--- a/src/components/Main/Results/ResultsCard.tsx
+++ b/src/components/Main/Results/ResultsCard.tsx
@@ -235,6 +235,7 @@ function ResultsCardFunction({
         toggleShowModal={toggleShowExportModal}
         canExport={canExport}
         result={result}
+        scenarioUrl={scenarioUrl}
       />
     </>
   )


### PR DESCRIPTION

## Related issues and PRs

Contributes to #461 

## Description

Fixes the broken "Shareable Link" export. The shareable link was being taken from the URL bar, but that is no longer a reliable source. This PR passes the shareable link as a param to the export modal.

## Impacted Areas in the application

Export.


## Testing

1. Run a simulation
2. Click 'export'
3. Select "copy shareable link"
 - Verify that the link contains URL params that resemble an exported scenario.
4. Paste the link into a new browser.
 - Verify that the new simulation's scenario matches the exported scenario.
