### PR TITLE
fix Issue440: translate moment strings in date picker and date dropdown when switch language

### DIFF
--- a/src/algorithms/utils/createMitigationInterval.ts
+++ b/src/algorithms/utils/createMitigationInterval.ts
@@ -1,4 +1,4 @@
-import moment from 'moment'
+import moment from 'moment/moment'
 import { v4 as uuidv4 } from 'uuid'
 import createColor from 'create-color'
 

--- a/src/components/Form/DateRangePicker.tsx
+++ b/src/components/Form/DateRangePicker.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 
-import moment from 'moment'
+import moment from 'moment/moment'
 import { DateRangePicker as AirbnbDateRangePicker, DateRangePickerShape, FocusedInputShape } from 'react-dates'
 
 import { DateRange } from '../../algorithms/types/Param.types'

--- a/src/components/Layout/LanguageSwitcher.tsx
+++ b/src/components/Layout/LanguageSwitcher.tsx
@@ -33,11 +33,11 @@ export default function LanguageSwitcher() {
   const selectedLang = getCurrentLang()
 
   return (
-    <Dropdown isOpen={dropdownOpen} toggle={toggle} className="pull-right" data-testid="LanguageSwitcher">
+    <Dropdown isOpen={dropdownOpen} toggle={toggle} data-testid="LanguageSwitcher">
       <DropdownToggle caret>
         <Lang lang={SupportedLocales[selectedLang]} />
       </DropdownToggle>
-      <DropdownMenu>
+      <DropdownMenu positionFixed={true}>
         {(Object.keys(SupportedLocales) as SupportedLocale[]).map((key: SupportedLocale) => (
           <DropdownItem
             key={key}

--- a/src/components/Layout/LanguageSwitcher.tsx
+++ b/src/components/Layout/LanguageSwitcher.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { Dropdown, DropdownToggle, DropdownMenu, DropdownItem } from 'reactstrap'
 import i18next from 'i18next'
+import moment from 'moment/moment'
 
 import SupportedLocales, { Locale, SupportedLocale } from '../../langs'
 
@@ -31,6 +32,7 @@ export default function LanguageSwitcher() {
   const [dropdownOpen, setDropdownOpen] = useState(false)
   const toggle = () => setDropdownOpen((prevState) => !prevState)
   const selectedLang = getCurrentLang()
+  moment.locale(SupportedLocales[selectedLang].lang)
 
   return (
     <Dropdown isOpen={dropdownOpen} toggle={toggle} data-testid="LanguageSwitcher">
@@ -45,6 +47,7 @@ export default function LanguageSwitcher() {
               i18next.changeLanguage(SupportedLocales[key].lang, () => {
                 LocalStorage.set(LOCAL_STORAGE_KEYS.LANG, SupportedLocales[key].lang)
               })
+              moment.locale(SupportedLocales[key].lang)
             }}
           >
             <Lang lang={SupportedLocales[key]} />

--- a/src/components/Layout/NavigationBar.tsx
+++ b/src/components/Layout/NavigationBar.tsx
@@ -4,7 +4,7 @@ import { RouteComponentProps, withRouter } from 'react-router-dom'
 
 import { FaGithub, FaTwitter } from 'react-icons/fa'
 
-// import LanguageSwitcher from './LanguageSwitcher'
+import LanguageSwitcher from './LanguageSwitcher'
 import LinkExternal from '../Router/LinkExternal'
 import NavigationLink from './NavigationLink'
 
@@ -59,7 +59,7 @@ function NavigationBar({ navLinks, location }: NavigationBarProps) {
           </LinkExternal>
         </div>
 
-        {/* <LanguageSwitcher />*/}
+        <LanguageSwitcher />
       </div>
     </nav>
   )

--- a/src/components/Main/PrintPage/TableResult.tsx
+++ b/src/components/Main/PrintPage/TableResult.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import moment from 'moment'
+import moment from 'moment/moment'
 import chroma from 'chroma-js'
 
 import { AlgorithmResult, ExportedTimePoint } from '../../../algorithms/types/Result.types'

--- a/src/components/Main/Scenario/ScenarioCardEpidemiological.tsx
+++ b/src/components/Main/Scenario/ScenarioCardEpidemiological.tsx
@@ -1,15 +1,12 @@
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-import moment from 'moment'
+import moment from 'moment/moment'
 
 import { FormikErrors, FormikTouched } from 'formik'
 
 import { CardWithoutDropdown } from '../../Form/CardWithoutDropdown'
 import { FormDropdown } from '../../Form/FormDropdown'
 import { FormSpinBox } from '../../Form/FormSpinBox'
-
-const months = moment.months()
-const monthOptions = months.map((month, i) => ({ value: i, label: month }))
 
 export interface ScenarioCardEpidemiologicalProps {
   errors?: FormikErrors<any>
@@ -74,7 +71,7 @@ function ScenarioCardEpidemiological({ errors, touched }: ScenarioCardEpidemiolo
         identifier="epidemiological.peakMonth"
         label={t('Seasonal peak')}
         help={t('Time of the year with peak transmission')}
-        options={monthOptions}
+        options={moment.months().map((month, i) => ({ value: i, label: month }))}
         errors={errors}
         touched={touched}
       />


### PR DESCRIPTION
## Related issues and PRs
issue #440 
 - 

## Description
The locale of moment is not set when switch language, which cause the date picker and date dropdown is not translated according to local.
Set locale in moment when switch locale in language dropdown.

## Impacted Areas in the application
languageSwitcher
createMitigationInterval
DateRangePicker
TableResult
ScenarioCardEpidemiological


## Testing
click date dropdown in scenario card -- all the strings translated
click date picker -- all the strings translated
switch language -- all the strings translated to the selected locale
![image](https://user-images.githubusercontent.com/10755641/78848904-ed9a8100-79c7-11ea-9b5e-8cf1fe591598.png)
![image](https://user-images.githubusercontent.com/10755641/78848929-fb500680-79c7-11ea-9b8c-bdee526ac17d.png)





