### PR TITLE
Disable pointer events for scatter plot elements

### DIFF
--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -102,6 +102,13 @@ input[type='number']::-webkit-outer-spin-button {
   z-index: 999;
 }
 
+// rechart <Scatter /> elements can cause the tooltip to hide. (and appear with
+// a payload it cannot handle). So they are set to ignore mouse events.
+// https://github.com/neherlab/covid19_scenarios/issues/234#issuecomment-612294282
+.recharts-scatter-symbol {
+  pointer-events: none;
+}
+
 .truncate-ellipsis {
   white-space: nowrap;
   overflow: hidden;


### PR DESCRIPTION
## Related issues and PRs

Fixes #234 

## Description

This simple changes causes the tooltip to remain in view while the mouse is in the graph. Previously it would disappear and appear truncated due to being triggered by the scatter plots. 

## Impacted Areas in the application

Graph tooltips.

## Testing

Mouse over the graph 🐭 📈 
