### PR TITLE
Allow for export of all stratified simulation data

### DIFF
--- a/src/algorithms/model.ts
+++ b/src/algorithms/model.ts
@@ -556,13 +556,11 @@ export function collectTotals(trajectory: SimulationTimePoint[], ages: string[])
   return res
 }
 
-export function exportSimulation(result: UserResult, ageGroups?: string[]) {
+export function exportSimulation(result: UserResult, ageGroups: string[] = ['total']) {
   // Store parameter values
 
   // Down sample trajectory to once a day.
   // TODO: Make the down sampling interval a parameter
-
-  const ageGroupsExported = ageGroups ? ageGroups : ['total']
 
   const header = keys(result.trajectory[0].current)
   const tsvHeader: string[] = header.map((x) => (x === 'critical' ? 'ICU' : x))
@@ -572,7 +570,7 @@ export function exportSimulation(result: UserResult, ageGroups?: string[]) {
 
   let buf = 'time'
   tsvHeader.concat(tsvHeaderCumulative).forEach((hdr) => {
-    ageGroupsExported.forEach((age) => {
+    ageGroups.forEach((age) => {
       buf += `\t${hdr} (${age})`
     })
   })
@@ -587,13 +585,13 @@ export function exportSimulation(result: UserResult, ageGroups?: string[]) {
     pop[t] = true
     let buf = t
     header.forEach((k) => {
-      ageGroupsExported.forEach((age) => {
+      ageGroups.forEach((age) => {
         buf += `\t${Math.round(d.current[k][age])}`
       })
     })
 
     headerCumulative.forEach((k) => {
-      ageGroupsExported.forEach((age) => {
+      ageGroups.forEach((age) => {
         buf += `\t${Math.round(d.cumulative[k][age])}`
       })
     })

--- a/src/algorithms/model.ts
+++ b/src/algorithms/model.ts
@@ -556,12 +556,12 @@ export function collectTotals(trajectory: SimulationTimePoint[], ages: string[])
   return res
 }
 
-export function exportSimulation(result: UserResult, ...ageGroups: string[]) {
+export function exportSimulation(result: UserResult, ageGroups?: string[]) {
   // Store parameter values
 
   // Down sample trajectory to once a day.
   // TODO: Make the down sampling interval a parameter
-  if (ageGroups.length == 0) {
+  if (!ageGroups || ageGroups.length == 0) {
     ageGroups = ['total']
   }
 

--- a/src/algorithms/model.ts
+++ b/src/algorithms/model.ts
@@ -526,14 +526,14 @@ export function collectTotals(trajectory: SimulationTimePoint[], ages: string[])
     // TODO(nnoll): Typescript linting isn't happy here
     Object.keys(tp.current).forEach((k) => {
       if (k === 'exposed') {
-        tp.current[k].total = 0
-        Object.values(d.current[k]).forEach((x) => {
+        tp.current.exposed.total = 0
+        Object.values(d.current.exposed).forEach((x) => {
           x.forEach((y) => {
             tp.current[k].total += y
           })
         })
-        Object.keys(d.current[k]).forEach((a, i) => {
-          tp.current[k][a] = d.current[k][i].reduce((a, b) => a + b, 0)
+        ages.forEach((age, i) => {
+          tp.current[k][age] = d.current.exposed[i].reduce((a, b) => a + b, 0)
         })
       } else {
         ages.forEach((age, i) => {

--- a/src/algorithms/model.ts
+++ b/src/algorithms/model.ts
@@ -561,9 +561,8 @@ export function exportSimulation(result: UserResult, ageGroups?: string[]) {
 
   // Down sample trajectory to once a day.
   // TODO: Make the down sampling interval a parameter
-  if (!ageGroups || ageGroups.length == 0) {
-    ageGroups = ['total']
-  }
+
+  const ageGroupsExported = ageGroups ? ageGroups : ['total']
 
   const header = keys(result.trajectory[0].current)
   const tsvHeader: string[] = header.map((x) => (x === 'critical' ? 'ICU' : x))
@@ -572,13 +571,8 @@ export function exportSimulation(result: UserResult, ageGroups?: string[]) {
   const tsvHeaderCumulative = headerCumulative.map((x) => `cumulative_${x}`)
 
   let buf = 'time'
-  tsvHeader.forEach((hdr) => {
-    ageGroups.forEach((age) => {
-      buf += `\t${hdr} (${age})`
-    })
-  })
-  tsvHeaderCumulative.forEach((hdr) => {
-    ageGroups.forEach((age) => {
+  tsvHeader.concat(tsvHeaderCumulative).forEach((hdr) => {
+    ageGroupsExported.forEach((age) => {
       buf += `\t${hdr} (${age})`
     })
   })
@@ -593,13 +587,13 @@ export function exportSimulation(result: UserResult, ageGroups?: string[]) {
     pop[t] = true
     let buf = t
     header.forEach((k) => {
-      ageGroups.forEach((age) => {
+      ageGroupsExported.forEach((age) => {
         buf += `\t${Math.round(d.current[k][age])}`
       })
     })
 
     headerCumulative.forEach((k) => {
-      ageGroups.forEach((age) => {
+      ageGroupsExported.forEach((age) => {
         buf += `\t${Math.round(d.cumulative[k][age])}`
       })
     })

--- a/src/algorithms/utils/exportResult.ts
+++ b/src/algorithms/utils/exportResult.ts
@@ -47,7 +47,7 @@ export async function exportAll(result: AlgorithmResult) {
   saveAs(zipFile, 'covid.params.results.zip')
 }
 
-export function exportResult(result: AlgorithmResult, fileName: string, ...ageGroups: string[]) {
+export function exportResult(result: AlgorithmResult, fileName: string, ageGroups?: string[]) {
   if (!result) {
     throw new Error(`Algorithm result expected, but got ${result}`)
   }
@@ -65,7 +65,7 @@ export function exportResult(result: AlgorithmResult, fileName: string, ...ageGr
     return
   }
 
-  saveFile(exportSimulation(deterministic, ...ageGroups), fileName)
+  saveFile(exportSimulation(deterministic, ageGroups), fileName)
 }
 
 export function exportParams(result: AlgorithmResult) {

--- a/src/algorithms/utils/exportResult.ts
+++ b/src/algorithms/utils/exportResult.ts
@@ -39,14 +39,15 @@ export async function exportAll(result: AlgorithmResult) {
   if (!deterministic) {
     console.error('Error: the results of the simulation cannot be exported because they are nondeterministic')
   } else {
-    zip.file('covid.results.deterministic.tsv', exportSimulation(deterministic, 'total'))
+    const path = 'covid.summary.tsv'
+    zip.file(path, exportSimulation(deterministic, path))
   }
 
   const zipFile = await zip.generateAsync({ type: 'blob' })
   saveAs(zipFile, 'covid.params.results.zip')
 }
 
-export function exportResult(result: AlgorithmResult) {
+export function exportResult(result: AlgorithmResult, fileName: string, ...ageGroups: string[]) {
   if (!result) {
     throw new Error(`Algorithm result expected, but got ${result}`)
   }
@@ -64,7 +65,7 @@ export function exportResult(result: AlgorithmResult) {
     return
   }
 
-  saveFile(exportSimulation(deterministic, 'total'), 'covid.results.deterministic.tsv')
+  saveFile(exportSimulation(deterministic, ...ageGroups), fileName)
 }
 
 export function exportParams(result: AlgorithmResult) {

--- a/src/algorithms/utils/exportResult.ts
+++ b/src/algorithms/utils/exportResult.ts
@@ -39,7 +39,7 @@ export async function exportAll(result: AlgorithmResult) {
   if (!deterministic) {
     console.error('Error: the results of the simulation cannot be exported because they are nondeterministic')
   } else {
-    zip.file('covid.results.deterministic.tsv', exportSimulation(deterministic))
+    zip.file('covid.results.deterministic.tsv', exportSimulation(deterministic, 'total'))
   }
 
   const zipFile = await zip.generateAsync({ type: 'blob' })
@@ -64,7 +64,7 @@ export function exportResult(result: AlgorithmResult) {
     return
   }
 
-  saveFile(exportSimulation(deterministic), 'covid.results.deterministic.tsv')
+  saveFile(exportSimulation(deterministic, 'total'), 'covid.results.deterministic.tsv')
 }
 
 export function exportParams(result: AlgorithmResult) {

--- a/src/components/Main/Results/ExportSimulationDialog.tsx
+++ b/src/components/Main/Results/ExportSimulationDialog.tsx
@@ -67,7 +67,7 @@ export default function ExportSimulationDialog({
               <td>
                 <Button
                   disabled={!(result?.deterministic ?? null)}
-                  onClick={() => result && exportResult(result, 'covid.summary.tsv', )}
+                  onClick={() => result && exportResult(result, 'covid.summary.tsv')}
                   color="primary"
                   size="sm"
                 >

--- a/src/components/Main/Results/ExportSimulationDialog.tsx
+++ b/src/components/Main/Results/ExportSimulationDialog.tsx
@@ -61,13 +61,35 @@ export default function ExportSimulationDialog({
               </td>
             </tr>
             <tr>
-              <td>covid.results.deterministic.tsv</td>
-              <td>{t('The deterministic results of the simulation')}</td>
+              <td>covid.summary.tsv</td>
+              <td>{t('The summarized results of the simulation')}</td>
               <td>TSV</td>
               <td>
                 <Button
                   disabled={!(result?.deterministic ?? null)}
-                  onClick={() => result && exportResult(result)}
+                  onClick={() => result && exportResult(result, 'covid.summary.tsv')}
+                  color="primary"
+                  size="sm"
+                >
+                  {t('Download')}
+                </Button>
+              </td>
+            </tr>
+            <tr>
+              <td>covid.allresults.tsv</td>
+              <td>{t('The full age-stratified results of the simulation')}</td>
+              <td>TSV</td>
+              <td>
+                <Button
+                  disabled={!(result?.deterministic ?? null)}
+                  onClick={() =>
+                    result &&
+                    exportResult(
+                      result,
+                      'covid.allresults.tsv',
+                      ...Object.keys(result.deterministic.trajectory[0].current.severe),
+                    )
+                  }
                   color="primary"
                   size="sm"
                 >

--- a/src/components/Main/Results/ExportSimulationDialog.tsx
+++ b/src/components/Main/Results/ExportSimulationDialog.tsx
@@ -67,7 +67,7 @@ export default function ExportSimulationDialog({
               <td>
                 <Button
                   disabled={!(result?.deterministic ?? null)}
-                  onClick={() => result && exportResult(result, 'covid.summary.tsv')}
+                  onClick={() => result && exportResult(result, 'covid.summary.tsv', )}
                   color="primary"
                   size="sm"
                 >
@@ -87,7 +87,7 @@ export default function ExportSimulationDialog({
                     exportResult(
                       result,
                       'covid.allresults.tsv',
-                      ...Object.keys(result.deterministic.trajectory[0].current.severe),
+                      Object.keys(result.deterministic.trajectory[0].current.severe),
                     )
                   }
                   color="primary"


### PR DESCRIPTION
## Related issues and PRs
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->
Solves #504.

## Description
<!-- Goal of the pull request -->
Generalizes the exportSimulation function to accept a variable number of arguments that are keys into userResult. If none are given, it will default to only reporting the total number for each category.

Will add an additional export category that downloads a large tsv table with all age stratified data.

## Impacted Areas in the application
<!-- Components of the application that this PR will change -->

model.ts
utils/exportResult.ts

## Testing
<!-- Steps to test the changes proposed by this PR -->

Download tsv files and see that they are properly formatted.