### PR TITLE
Variable number of new empirical cases now depends on infectious window.

### DIFF
--- a/src/components/Main/Results/ChartCommon.ts
+++ b/src/components/Main/Results/ChartCommon.ts
@@ -56,13 +56,15 @@ export const linesToPlot: LineProps[] = [
   { key: DATA_POINTS.ICUbeds, color: colors.ICUbeds, name: 'Total ICU/ICM beds', legendType: 'none' },
 ]
 
-export const observationsToPlot: LineProps[] = [
-  { key: DATA_POINTS.ObservedCases, color: colors.cumulativeCases, name: 'Cumulative cases (data)' },
-  { key: DATA_POINTS.ObservedNewCases, color: colors.newCases, name: 'Cases past 3 days (data)' },
-  { key: DATA_POINTS.ObservedHospitalized, color: colors.severe, name: 'Patients in hospital (data)' },
-  { key: DATA_POINTS.ObservedICU, color: colors.critical, name: 'Patients in ICU (data)' },
-  { key: DATA_POINTS.ObservedDeaths, color: colors.fatality, name: 'Cumulative deaths (data)' },
-]
+export function observationsToPlot(casesDelta: number): LineProps[] {
+  return [
+    { key: DATA_POINTS.ObservedCases, color: colors.cumulativeCases, name: 'Cumulative cases (data)' },
+    { key: DATA_POINTS.ObservedNewCases, color: colors.newCases, name: `Cases past ${casesDelta} day(s) (data)` },
+    { key: DATA_POINTS.ObservedHospitalized, color: colors.severe, name: 'Patients in hospital (data)' },
+    { key: DATA_POINTS.ObservedICU, color: colors.critical, name: 'Patients in ICU (data)' },
+    { key: DATA_POINTS.ObservedDeaths, color: colors.fatality, name: 'Cumulative deaths (data)' },
+  ]
+}
 
 export function translatePlots(t: TFunction, lines: LineProps[]): LineProps[] {
   return lines.map((line) => {

--- a/src/components/Main/Results/DeterministicLinePlot.tsx
+++ b/src/components/Main/Results/DeterministicLinePlot.tsx
@@ -197,7 +197,7 @@ export function DeterministicLinePlot({
   const tMin = _.minBy(plotData, 'time')!.time // eslint-disable-line @typescript-eslint/no-non-null-assertion
   const tMax = _.maxBy(plotData, 'time')!.time // eslint-disable-line @typescript-eslint/no-non-null-assertion
 
-  const reducedObservationsToPlot = translatePlots(t, observationsToPlot).filter((itemToPlot) => {
+  const reducedObservationsToPlot = translatePlots(t, observationsToPlot(caseBaseStep)).filter((itemToPlot) => {
     if (observations.length !== 0) {
       if (countObservations.cases && itemToPlot.key === DATA_POINTS.ObservedCases) {
         return true
@@ -320,6 +320,7 @@ export function DeterministicLinePlot({
                     <LinePlotTooltip
                       valueFormatter={tooltipValueFormatter}
                       itemsToDisplay={tooltipItemsToDisplay}
+                      deltaCaseDays={caseBaseStep}
                       {...props}
                     />
                   )}

--- a/src/components/Main/Results/DeterministicLinePlot.tsx
+++ b/src/components/Main/Results/DeterministicLinePlot.tsx
@@ -69,36 +69,20 @@ function computeNewEmpiricalCases(
   if (!cumulativeCounts) {
     return [newEmpiricalCases, deltaDay]
   }
-  const windowIsInt = deltaInt === 0
-
-  const containsDataFrom = (day: number) =>
-    cumulativeCounts[day].cases !== null && cumulativeCounts[day].cases !== undefined
 
   for (let day = deltaDay; day < cumulativeCounts.length; day++) {
-    if (windowIsInt) {
-      const startDay = day - deltaDay
-      if (containsDataFrom(day) && containsDataFrom(startDay)) {
-        const nowCases = cumulativeCounts[day].cases
-        const oldCases = cumulativeCounts[startDay].cases
+    const startDay = day - deltaDay
+    const startDayPlus = day - deltaDay - 1
 
-        const newCases = verifyPositive(nowCases! - oldCases!)
-
-        newEmpiricalCases.push(newCases)
-        continue
-      }
-    } else {
-      const startDay = day - deltaDay
-      const startDayPlus = day - deltaDay - 1
-      if (containsDataFrom(day) && containsDataFrom(startDay) && containsDataFrom(startDayPlus)) {
-        const nowCases = cumulativeCounts[day].cases
-        const oldCases = cumulativeCounts[startDay].cases
-        const olderCases = cumulativeCounts[startDayPlus].cases
-
-        const newCases = verifyPositive((1 - deltaDay) * (nowCases - oldCases) + deltaDay * (nowCases - olderCases))
-
-        newEmpiricalCases[day] = newCases
-        continue
-      }
+    const nowCases = cumulativeCounts[day].cases
+    const oldCases = cumulativeCounts[startDay].cases
+    const olderCases = cumulativeCounts[startDayPlus]?.cases
+    if (oldCases && nowCases) {
+      const newCases = verifyPositive(
+        olderCases ? (1 - deltaInt) * (nowCases - oldCases) + deltaInt * (nowCases - olderCases) : nowCases - oldCases,
+      )
+      newEmpiricalCases.push(newCases)
+      continue
     }
     newEmpiricalCases[day] = undefined
   }

--- a/src/components/Main/Results/DeterministicLinePlot.tsx
+++ b/src/components/Main/Results/DeterministicLinePlot.tsx
@@ -70,7 +70,11 @@ function computeNewEmpiricalCases(
     return [newEmpiricalCases, deltaDay]
   }
 
-  for (let day = deltaDay; day < cumulativeCounts.length; day++) {
+  cumulativeCounts.forEach((_0, day) => {
+    if (day < deltaDay) {
+      return
+    }
+
     const startDay = day - deltaDay
     const startDayPlus = day - deltaDay - 1
 
@@ -82,10 +86,10 @@ function computeNewEmpiricalCases(
         olderCases ? (1 - deltaInt) * (nowCases - oldCases) + deltaInt * (nowCases - olderCases) : nowCases - oldCases,
       )
       newEmpiricalCases.push(newCases)
-      continue
+      return
     }
     newEmpiricalCases[day] = undefined
-  }
+  })
 
   return [newEmpiricalCases, deltaDay]
 }

--- a/src/components/Main/Results/DeterministicLinePlot.tsx
+++ b/src/components/Main/Results/DeterministicLinePlot.tsx
@@ -71,7 +71,8 @@ function computeNewEmpiricalCases(
   }
   const windowIsInt = deltaInt === 0
 
-  const containsDataFrom = (day: number) => cumulativeCounts[day].cases !== null
+  const containsDataFrom = (day: number) =>
+    cumulativeCounts[day].cases !== null && cumulativeCounts[day].cases !== undefined
 
   for (let day = deltaDay; day < cumulativeCounts.length; day++) {
     if (windowIsInt) {
@@ -93,13 +94,13 @@ function computeNewEmpiricalCases(
         const oldCases = cumulativeCounts[startDay].cases
         const olderCases = cumulativeCounts[startDayPlus].cases
 
-        const newCases = verifyPositive((1 - deltaDay) * (nowCases! - oldCases!) + deltaDay * (nowCases! - olderCases!))
+        const newCases = verifyPositive((1 - deltaDay) * (nowCases - oldCases) + deltaDay * (nowCases - olderCases))
 
-        newEmpiricalCases.push(newCases)
+        newEmpiricalCases[day] = newCases
         continue
       }
     }
-    newEmpiricalCases.push(undefined)
+    newEmpiricalCases[day] = undefined
   }
 
   return [newEmpiricalCases, deltaDay]

--- a/src/components/Main/Results/LinePlotTooltip.tsx
+++ b/src/components/Main/Results/LinePlotTooltip.tsx
@@ -14,6 +14,7 @@ interface LinePlotItem extends TooltipItem {
 export interface LinePlotTooltipProps extends TooltipProps {
   valueFormatter: (value: number | string) => string
   itemsToDisplay?: string[]
+  deltaCaseDays: number
 }
 
 export function LinePlotTooltip({
@@ -23,6 +24,7 @@ export function LinePlotTooltip({
   valueFormatter,
   labelFormatter,
   itemsToDisplay,
+  deltaCaseDays,
 }: LinePlotTooltipProps) {
   const { t } = useTranslation()
 
@@ -36,7 +38,7 @@ export function LinePlotTooltip({
 
   const tooltipItems = []
     .concat(
-      translatePlots(t, observationsToPlot).map((observationToPlot) => ({
+      translatePlots(t, observationsToPlot(deltaCaseDays)).map((observationToPlot) => ({
         ...observationToPlot,
         displayUndefinedAs: '-',
       })) as never,


### PR DESCRIPTION
## Related issues and PRs
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->

Solves Issue #154.

## Description
<!-- Goal of the pull request -->

As of now we have hardcoded in the assumption that the infectious window is 3 days in our display of new cases. This is suboptimal in the event that one wants to explore scenarios in which this differs from our default assumption. This PR solves this by parameterizing this computation by our input parameter. 

I've also kept in general insofar that I don't assume this is an integer as the infectious window we give is a average of a distribution so could in principle be a real number.

## Impacted Areas in the application
<!-- Components of the application that this PR will change -->

ChartCommon.ts
DeterminsticLinePlot.tsx
LinePlotTooltip.tsx

## Testing
<!-- Steps to test the changes proposed by this PR -->

Check that the function behaves as expected on changing the infectious period.