### PR TITLE
#443/Allow fine grained values in numeric inputs while preserving step size.

### DIFF
--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -188,7 +188,7 @@ function Main() {
             const canRun = isValid && severityTableIsValid(severity)
 
             return (
-              <Form className="form">
+              <Form className="form" noValidate>
                 <Row>
                   <Col lg={4} xl={6} className="py-1">
                     <ScenarioCard


### PR DESCRIPTION
## Related issues and PRs

Fixes #443, and possibly makes #454 look silly.
Similar to hotfix #534  

## Description
<!-- Goal of the pull request -->

Browsers reject `<input type="number" step="x"/>` as invalid when the value is not a multiple of the `step` attribute. For this app, such behaviour is undesirable because users may want to enter a number with higher precision than permitted by the step size. And, validation is already being performed by Formik. Therefore browser-level validation is not necessary. This PR disables browser level form validation.

## Impacted Areas in the application

This fix is aimed at numeric inputs but in effect applies to all form inputs.

## Testing

1. Select, for example, a mitigation interval value.
2. Change the value by adding a decimal component, like "40.4"
3. **Press enter**.
  - Observe no error message.
4. Test other non numeric fields
 - Confirm behavior remains as expected.
