### PR TITLE
use 'undefined' for empirical cases prior to the difference window

### DIFF
--- a/src/components/Main/Results/DeterministicLinePlot.tsx
+++ b/src/components/Main/Results/DeterministicLinePlot.tsx
@@ -72,6 +72,7 @@ function computeNewEmpiricalCases(
 
   cumulativeCounts.forEach((_0, day) => {
     if (day < deltaDay) {
+      newEmpiricalCases[day] = undefined
       return
     }
 


### PR DESCRIPTION

## Description
The way empirical cases were added to plot resulted in them being registered at the first date of the interval, rather than the last date (as it should since they are called in new cases in the last three days, not next 3 days). This adds undefined to the array for the first 3 days. 

## Impacted Areas in the application
plot


## Testing
double check plots. 
