### PR TITLE
refactor: move initial state handling out of Main

### DIFF
--- a/src/components/Main/HandleInitialState.test.tsx
+++ b/src/components/Main/HandleInitialState.test.tsx
@@ -41,10 +41,16 @@ describe('HandleInitialState', () => {
 
   it('passes initial scenario state', () => {
     const { getByText } = render(
-      <ThisTest component={({ initialState }) => <span>{initialState.scenarioState.data.population.country}</span>} />,
+      <ThisTest
+        component={({ initialState }) => (
+          <span>
+            {initialState.scenarioState.data.population.country} {initialState.isDefault ? 'true' : 'false'}
+          </span>
+        )}
+      />,
     )
 
-    expect(getByText(DEFAULT_OVERALL_SCENARIO_NAME)).not.toBeNull()
+    expect(getByText(`${DEFAULT_OVERALL_SCENARIO_NAME} true`)).not.toBeNull()
   })
 
   it('passes initial severity state', () => {
@@ -59,11 +65,15 @@ describe('HandleInitialState', () => {
     const { getByText } = render(
       <ThisTest
         testPushURL="/path?something_to_deserialize"
-        component={({ initialState }) => <span>{initialState.scenarioState.current}</span>}
+        component={({ initialState }) => (
+          <span>
+            {initialState.scenarioState.current} {initialState.isDefault ? 'true' : 'false'}
+          </span>
+        )}
       />,
     )
 
-    expect(getByText('?something_to_deserialize')).not.toBeNull()
+    expect(getByText('?something_to_deserialize false')).not.toBeNull()
   })
 
   it('clears search parameters from the URL', () => {

--- a/src/components/Main/HandleInitialState.test.tsx
+++ b/src/components/Main/HandleInitialState.test.tsx
@@ -1,0 +1,99 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { Router } from 'react-router-dom'
+import { createMemoryHistory, Location } from 'history'
+import HandleInitialState, { HandleInitialStateProps } from './HandleInitialState'
+import { State, DEFAULT_OVERALL_SCENARIO_NAME } from './state/state'
+import severityData from '../../assets/data/severityData.json'
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+require('./state/serialization/URLSerializer')
+
+jest.mock('./state/serialization/URLSerializer', () => ({
+  deserializeScenarioFromURL: (location: Location, state: State): State => {
+    return {
+      ...state,
+      ...(location.search ? { current: location.search } : {}),
+    }
+  },
+}))
+
+interface ThisTestProps extends HandleInitialStateProps {
+  testPushURL?: string
+}
+
+const ThisTest = ({ testPushURL, ...props }: ThisTestProps) => {
+  const history = createMemoryHistory()
+  if (testPushURL) {
+    history.push(testPushURL)
+  }
+
+  return (
+    <Router history={history}>
+      <HandleInitialState {...props} />
+    </Router>
+  )
+}
+
+describe('HandleInitialState', () => {
+  it('renders a component', () => {
+    const { getByText } = render(<ThisTest component={() => <span>wrapped</span>} />)
+
+    expect(getByText('wrapped')).not.toBeNull()
+  })
+
+  it('passes initial scenario state', () => {
+    const { getByText } = render(
+      <ThisTest component={({ initialState }) => <span>{initialState.scenarioState.data.population.country}</span>} />,
+    )
+
+    expect(getByText(DEFAULT_OVERALL_SCENARIO_NAME)).not.toBeNull()
+  })
+
+  it('passes initial severity state', () => {
+    const { getByText } = render(
+      <ThisTest component={({ initialState }) => <span>{initialState.severityTable[0].ageGroup}</span>} />,
+    )
+
+    expect(getByText(severityData[0].ageGroup)).not.toBeNull()
+  })
+
+  it('may pull state from the URL', () => {
+    const { getByText } = render(
+      <ThisTest
+        testPushURL="/path?something_to_deserialize"
+        component={({ initialState }) => <span>{initialState.scenarioState.current}</span>}
+      />,
+    )
+
+    expect(getByText('?something_to_deserialize')).not.toBeNull()
+  })
+
+  it('clears search parameters from the URL', () => {
+    const history = createMemoryHistory()
+    history.push('/somewhere?state')
+    history.push = jest.fn()
+
+    render(
+      <Router history={history}>
+        <HandleInitialState component={() => <span>wrapped</span>} />
+      </Router>,
+    )
+
+    expect(history.push).toHaveBeenCalledWith('/')
+  })
+
+  it('may not clear the URL when there is no search', () => {
+    const history = createMemoryHistory()
+    history.push('/somewhere')
+    history.push = jest.fn()
+
+    render(
+      <Router history={history}>
+        <HandleInitialState component={() => <span>wrapped</span>} />
+      </Router>,
+    )
+
+    expect(history.push).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/Main/HandleInitialState.test.tsx
+++ b/src/components/Main/HandleInitialState.test.tsx
@@ -6,9 +6,6 @@ import HandleInitialState, { HandleInitialStateProps } from './HandleInitialStat
 import { State, DEFAULT_OVERALL_SCENARIO_NAME } from './state/state'
 import severityData from '../../assets/data/severityData.json'
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-require('./state/serialization/URLSerializer')
-
 jest.mock('./state/serialization/URLSerializer', () => ({
   deserializeScenarioFromURL: (location: Location, state: State): State => {
     return {

--- a/src/components/Main/HandleInitialState.tsx
+++ b/src/components/Main/HandleInitialState.tsx
@@ -1,0 +1,39 @@
+import React, { useState, useEffect } from 'react'
+import { withRouter, RouteComponentProps } from 'react-router'
+
+import { defaultScenarioState, State } from './state/state'
+import { SeverityTableRow } from './Scenario/ScenarioTypes'
+import severityData from '../../assets/data/severityData.json'
+import { deserializeScenarioFromURL } from './state/serialization/URLSerializer'
+
+interface InitialState {
+  scenarioState: State
+  severityTable: SeverityTableRow[]
+}
+
+export interface InitialStateComponentProps {
+  initialState: InitialState
+}
+
+export interface HandleInitialStateProps {
+  component: React.ComponentType<InitialStateComponentProps>
+}
+
+function HandleInitialState({
+  history,
+  location,
+  component: Component,
+}: RouteComponentProps<{}> & HandleInitialStateProps) {
+  const [scenarioState] = useState<State>(deserializeScenarioFromURL(location, defaultScenarioState))
+
+  useEffect(() => {
+    if (location.search) {
+      history.push('/')
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  return <Component initialState={{ scenarioState, severityTable: severityData }} />
+}
+
+export default withRouter(HandleInitialState)

--- a/src/components/Main/HandleInitialState.tsx
+++ b/src/components/Main/HandleInitialState.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import { withRouter, RouteComponentProps } from 'react-router'
+import _ from 'lodash'
 
 import { defaultScenarioState, State } from './state/state'
 import { SeverityTableRow } from './Scenario/ScenarioTypes'
@@ -9,6 +10,7 @@ import { deserializeScenarioFromURL } from './state/serialization/URLSerializer'
 interface InitialState {
   scenarioState: State
   severityTable: SeverityTableRow[]
+  isDefault: boolean
 }
 
 export interface InitialStateComponentProps {
@@ -33,7 +35,15 @@ function HandleInitialState({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  return <Component initialState={{ scenarioState, severityTable: severityData }} />
+  return (
+    <Component
+      initialState={{
+        scenarioState,
+        severityTable: severityData,
+        isDefault: _.isEqual(scenarioState, defaultScenarioState),
+      }}
+    />
+  )
 }
 
 export default withRouter(HandleInitialState)

--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -15,7 +15,6 @@ import { run, intervalsToTimeSeries } from '../../algorithms/run'
 
 import LocalStorage, { LOCAL_STORAGE_KEYS } from '../../helpers/localStorage'
 
-import severityData from '../../assets/data/severityData.json'
 import { getCaseCountsData } from './state/caseCountsData'
 
 import { schema } from './validation/schema'
@@ -23,9 +22,10 @@ import { schema } from './validation/schema'
 import { setContainmentData, setPopulationData, setEpidemiologicalData, setSimulationData } from './state/actions'
 import { scenarioReducer } from './state/reducer'
 
-import { defaultScenarioState, State } from './state/state'
-import { deserializeScenarioFromURL, updateBrowserURL, buildLocationSearch } from './state/serialization/URLSerializer'
+import { State } from './state/state'
+import { buildLocationSearch } from './state/serialization/URLSerializer'
 
+import { InitialStateComponentProps } from './HandleInitialState'
 import { ResultsCard } from './Results/ResultsCard'
 import { ScenarioCard } from './Scenario/ScenarioCard'
 import { updateSeverityTable } from './Scenario/severityTableUpdate'
@@ -78,20 +78,16 @@ function getColumnSizes(areResultsMaximized: boolean) {
   return { colScenario: { xl: 6 }, colResults: { xl: 6 } }
 }
 
-const severityDefaults: SeverityTableRow[] = updateSeverityTable(severityData)
-
-function Main() {
+function Main({ initialState }: InitialStateComponentProps) {
   const [result, setResult] = useState<AlgorithmResult | undefined>()
-  const [autorunSimulation, setAutorunSimulation] = useState(false)
-  const [areResultsMaximized, setAreResultsMaximized] = useState(false)
-  const [scenarioState, scenarioDispatch] = useReducer(
-    scenarioReducer,
-    defaultScenarioState,
-    deserializeScenarioFromURL,
+  const [autorunSimulation, setAutorunSimulation] = useState(
+    LocalStorage.get<boolean>(LOCAL_STORAGE_KEYS.AUTORUN_SIMULATION) ?? false,
   )
+  const [areResultsMaximized, setAreResultsMaximized] = useState(false)
+  const [scenarioState, scenarioDispatch] = useReducer(scenarioReducer, initialState.scenarioState)
 
   // TODO: Can this complex state be handled by formik too?
-  const [severity, setSeverity] = useState<SeverityTableRow[]>(severityDefaults)
+  const [severity, setSeverity] = useState<SeverityTableRow[]>(updateSeverityTable(initialState.severityTable))
   const [printable, setPrintable] = useState(false)
   const openPrintPreview = () => setPrintable(true)
 
@@ -114,21 +110,6 @@ function Main() {
       runSimulation(params, scenarioState, severity, setResult, setEmpiricalCases),
     500,
   )
-
-  useEffect(() => {
-    // runs only once, when the component is mounted
-    const autorun = LocalStorage.get<boolean>(LOCAL_STORAGE_KEYS.AUTORUN_SIMULATION)
-    setAutorunSimulation(autorun ?? false)
-
-    // if the link contains query, we're executing the scenario (and displaying graphs)
-    // this is because the page was either shared via link, or opened in new tab
-    if (window.location.search) {
-      debouncedRun(allParams, scenarioState, severity)
-
-      // At this point the scenario params have been captured, and we can clean up the URL.
-      updateBrowserURL('/')
-    }
-  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     if (autorunSimulation) {

--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -112,6 +112,13 @@ function Main({ initialState }: InitialStateComponentProps) {
   )
 
   useEffect(() => {
+    // runs only once, when the component is mounted
+    if (!initialState.isDefault) {
+      debouncedRun(allParams, scenarioState, severity)
+    }
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
     if (autorunSimulation) {
       debouncedRun(allParams, scenarioState, severity)
     }

--- a/src/components/Main/state/serialization/URLSerializer.test.ts
+++ b/src/components/Main/state/serialization/URLSerializer.test.ts
@@ -1,5 +1,5 @@
 import { State } from '../state'
-import { buildLocationSearch, updateBrowserURL } from './URLSerializer'
+import { buildLocationSearch } from './URLSerializer'
 
 const SCENARIOS = ['CHE-Basel-Landschaft', 'CHE-Basel-Stadt']
 
@@ -77,13 +77,5 @@ describe('URLSerializer', () => {
 
   it('serializes application state and builds the location.search', () => {
     expect(buildLocationSearch(STATE)).toBe(LOCATION_SEARCH)
-  })
-
-  it('pushes to browser history', () => {
-    const spy = jest.spyOn(window.history, 'pushState')
-
-    updateBrowserURL('?foo=1&bar=baz')
-
-    expect(spy).toHaveBeenCalledWith('', '', '?foo=1&bar=baz')
   })
 })

--- a/src/components/Main/state/serialization/URLSerializer.ts
+++ b/src/components/Main/state/serialization/URLSerializer.ts
@@ -1,3 +1,4 @@
+import { Location } from 'history'
 import { State } from '../state'
 import { serialize, deserialize } from './StateSerializer'
 
@@ -30,17 +31,10 @@ export const buildLocationSearch = (scenarioState: State): string => {
 }
 
 /**
- * Updates browser search with a given URL
- */
-export const updateBrowserURL = (searchString: string): void => {
-  window.history.pushState('', '', searchString)
-}
-
-/**
  * Reads the browser URL and returna the updated application state
  */
-export const deserializeScenarioFromURL = (currentAppState: State): State => {
-  const { search } = window.location
+export const deserializeScenarioFromURL = (location: Location, currentAppState: State): State => {
+  const { search } = location
 
   if (search) {
     const searchParams = new URLSearchParams(search.slice(1)) // removing the first char ('?')

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import Main from '../components/Main/Main'
+import HandleInitialState from '../components/Main/HandleInitialState'
 import Disclaimer from '../components/Main/Disclaimer'
 
 import './Home.scss'
@@ -9,7 +10,7 @@ function Home() {
   return (
     <>
       <Disclaimer />
-      <Main />
+      <HandleInitialState component={Main} />
     </>
   )
 }


### PR DESCRIPTION
## Related issues and PRs

None.

## Description

- Moves initial state and URL handling out of `<Main />`
- Uses react-router instead of direct window.location manipulation
- Tests initial state expectations

## Impacted Areas in the application

Initial state.

## Testing

### For the change to defaults:

Land on /
form shows the initial state as expected
change vars
open in new tab
new tab shows the altered state as expected, url is /
reload and defaults are shown

export -> shareable link
Land on shareable link 
Page shows the altered state as expected, url is /
reload and defaults are shown

### For the change to Autorun

clear storage
reload
autorun should be disabled
click autorun
run() should occur
reload
autorun should be enabled
run() should occur

