### PR TITLE
Age group grid tab focus

### DIFF
--- a/src/components/Main/Scenario/SeverityTable.scss
+++ b/src/components/Main/Scenario/SeverityTable.scss
@@ -14,6 +14,10 @@
     padding: 0;
   }
 
+  & .dx-g-bs4-table-edit-cell {
+    padding: 0 !important;
+  }
+
   & td p {
     margin: 0;
   }

--- a/src/components/Main/Scenario/SeverityTable.tsx
+++ b/src/components/Main/Scenario/SeverityTable.tsx
@@ -9,7 +9,6 @@ import {
   EditingState,
   EditingColumnExtension,
   Row as TableRow,
-  Table as TableBase,
   DataTypeProvider,
   DataTypeProviderProps,
 } from '@devexpress/dx-react-grid'
@@ -53,7 +52,7 @@ const editingColumnExtensions: EditingColumnExtension[] = [
 ]
 const getRowId = (row: TableRow) => row.id
 
-export type HeaderCellProps = Partial<TableBase.DataCellProps> & TableHeaderRow.CellProps
+export type HeaderCellProps = Partial<Table.DataCellProps> & TableHeaderRow.CellProps
 
 export function HeaderCell({ column }: HeaderCellProps) {
   const { title } = column
@@ -64,6 +63,18 @@ export function HeaderCell({ column }: HeaderCellProps) {
   ))
 
   return <td title={title}>{content}</td>
+}
+
+interface SeverityTableCellProps extends Table.DataCellProps {
+  onClick?: (e: MouseEvent) => void
+}
+
+const SeverityTableCell = ({ onClick, column, ...props }: SeverityTableCellProps) => {
+  const editingColumnExtension = editingColumnExtensions.find(
+    (editingExtension) => column.name === editingExtension.columnName,
+  )
+  const editable = !editingColumnExtension || editingColumnExtension.editingEnabled
+  return <Table.Cell {...props} tabIndex={editable ? 0 : -1} onFocus={editable ? onClick : undefined} column={column} />
 }
 
 const DecimalFormatter: React.FC<DataTypeProvider.ValueFormatterProps> = ({ value }) => (
@@ -102,24 +113,12 @@ function SeverityTable({ severity, setSeverity, scenarioState, scenarioDispatch 
   const commitChanges = ({ added, changed, deleted }: ChangeSet) => {
     let changedRows: SeverityTableRow[] = []
 
-    if (added) {
-      const startingAddedId = severity.length > 0 ? severity[severity.length - 1].id + 1 : 0
-      changedRows = [
-        ...severity,
-        ...added.map((row, index) => ({
-          id: startingAddedId + index,
-          ...row,
-        })),
-      ]
+    if (added || deleted) {
+      console.warn('Adds or deletes are not supported')
     }
 
     if (changed) {
       changedRows = severity.map((row) => (changed[row.id] ? { ...row, ...changed[row.id] } : row))
-    }
-
-    if (deleted) {
-      const deletedSet = new Set(deleted)
-      changedRows = severity.filter((row) => !deletedSet.has(row.id))
     }
 
     const ageDistribution: AgeDistribution = { ...scenarioState.ageDistribution }
@@ -138,8 +137,14 @@ function SeverityTable({ severity, setSeverity, scenarioState, scenarioDispatch 
     })
 
     setAgeDistributionErrors(thisAgeDistributionErrors)
-    scenarioDispatch(setAgeDistributionData({ data: ageDistribution }))
-    setSeverity(updateSeverityTable(changedRows))
+
+    if (!_.isEqual(ageDistribution, scenarioState.ageDistribution)) {
+      scenarioDispatch(setAgeDistributionData({ data: ageDistribution }))
+    }
+    const updatedSeverityTable = updateSeverityTable(changedRows)
+    if (!_.isEqual(updatedSeverityTable, severity)) {
+      setSeverity(updatedSeverityTable)
+    }
   }
 
   const severityWithAgeDistribution = severity.map((ageRow) => {
@@ -155,7 +160,7 @@ function SeverityTable({ severity, setSeverity, scenarioState, scenarioDispatch 
 
             <DecimalTypeProvider for={['totalFatal']} />
 
-            <Table columnExtensions={columnExtensions} />
+            <Table columnExtensions={columnExtensions} cellComponent={SeverityTableCell} />
 
             <TableInlineCellEditing startEditAction={'click'} selectTextOnEditStart />
 


### PR DESCRIPTION
## Related issues and PRs

None

## Description

Tab focus when editing the Severity Table did not behave as expected, with this change:

- Tab moves focus to the next editable cell
- Only editable cells can get focus
- Edits only propagate when a change has occurred

## Impacted Areas in the application

Editing the age group (`SeverityTable`) grid.

## Testing

Edit cells in the severity table and ensure that they propagate to run().
Both in the age distribution array and the severity table.