### PR TITLE
add schema for r0 & mitigationValue

### DIFF
--- a/src/components/Main/validation/schema.ts
+++ b/src/components/Main/validation/schema.ts
@@ -50,6 +50,8 @@ export const schema = yup.object().shape({
     overflowSeverity: yup.number().required(MSG_REQUIRED).positive(MSG_POSITIVE),
 
     peakMonth: yup.number().required(MSG_REQUIRED).min(0, MSG_POSITIVE).max(11),
+
+    r0: yup.array().of(yup.number().required(MSG_REQUIRED).min(0, MSG_NON_NEGATIVE)).min(2).max(2),
   }),
 
   containment: yup.object().shape({
@@ -57,6 +59,11 @@ export const schema = yup.object().shape({
       yup.object({
         color: yup.string().required(MSG_REQUIRED),
         id: yup.string().required(MSG_REQUIRED),
+        mitigationValue: yup
+          .array()
+          .of(yup.number().min(0, MSG_NON_NEGATIVE).max(100).required(MSG_REQUIRED))
+          .min(2)
+          .max(2),
         name: yup.string().required(MSG_REQUIRED),
         timeRange: dateRange().required(MSG_REQUIRED),
       }),


### PR DESCRIPTION
## Related issues and PRs

Contributes to #512 

## Description

Restores the schema for r0 & mitigationValue but as a tuple.

## Impacted Areas in the application

Form validity.

## Testing

Change r0, mitigationValue.
Note: the slider widgets enforce their own schema so it is not possible to break the schema check.
