### PR TITLE
feat: serve sourcemaps in production

### DIFF
--- a/config/webpack/webpack.client.babel.ts
+++ b/config/webpack/webpack.client.babel.ts
@@ -149,7 +149,7 @@ export default {
   devServer: {
     contentBase: path.join(buildPath, '..'),
     before: (app: express.Application) => {
-      app.use(express.static(path.join(buildPath, '..', 'sourcemaps')))
+      app.use(express.static(path.join(buildPath, 'sourcemaps')))
       app.use(express.static(path.join(moduleRoot, 'static')))
     },
     compress: true,
@@ -382,19 +382,19 @@ export default {
 
     new ExtraWatchWebpackPlugin({
       files: [
-        path.join(moduleRoot, 'generated/**'),
+        path.join(moduleRoot, 'src/.generated/**'),
         path.join(moduleRoot, 'src/types/**/*.d.ts'),
       ],
       dirs: [],
     }),
 
     new webpack.SourceMapDevToolPlugin({
-      filename: '../sourcemaps/[filebase].map[query]',
-      publicPath: '/sourcemaps/',
+      filename: 'sourcemaps/[filebase].map[query]',
+      publicPath: '/',
       // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
       // @ts-ignore: BUG: This parameter is missing in @types/webpack declarations
-      fileContext: 'web/content/sourcemaps',
-      noSources: production,
+      fileContext: 'web',
+      noSources: false,
     }),
 
     analyze &&


### PR DESCRIPTION
## Related issues and PRs
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->

## Description
<!-- Goal of the pull request -->

This moves `sourcemaps/` directory to the root of the deployed application, so that the source maps are autodeployed in production. As this is an open-source project, we don't have anything to hide.

## Impacted Areas in the application
<!-- Components of the application that this PR will change -->

dev experience

## Testing
<!-- Steps to test the changes proposed by this PR -->
