### PR TITLE
chore: only process package transpilation whitelist in production

### DIFF
--- a/config/webpack/lib/webpackLoadJavascript.ts
+++ b/config/webpack/lib/webpackLoadJavascript.ts
@@ -10,9 +10,13 @@ import { PluginOptions } from '@babel/core'
  *
  */
 function excludeNodeModulesExcept(
-  transpiledLibs: string[],
-  nonTranspiledLibs: string[],
+  transpiledLibs?: string[] | boolean,
+  nonTranspiledLibs?: string[] | boolean,
 ) {
+  if (!transpiledLibs || !Array.isArray(transpiledLibs)) {
+    return /node_modules/
+  }
+
   let pathSep: typeof path.sep | string = path.sep
   if (pathSep === '\\') {
     // must be quoted for use in a regexp:
@@ -27,7 +31,11 @@ function excludeNodeModulesExcept(
     if (modulePath.includes('node_modules')) {
       // eslint-disable-next-line no-loops/no-loops
       for (const element of moduleRegExps) {
-        if (nonTranspiledLibs.some((lib) => modulePath.includes(lib))) {
+        if (
+          nonTranspiledLibs &&
+          Array.isArray(nonTranspiledLibs) &&
+          nonTranspiledLibs.some((lib) => modulePath.includes(lib))
+        ) {
           // eslint-disable-next-line no-continue
           continue
         }
@@ -47,8 +55,8 @@ export interface WebpackLoadJavaScriptParams {
   options?: PluginOptions
   eslintConfigFile?: string | boolean
   sourceMaps: boolean
-  transpiledLibs?: string[]
-  nonTranspiledLibs?: string[]
+  transpiledLibs?: string[] | boolean
+  nonTranspiledLibs?: string[] | boolean
 }
 
 export default function webpackLoadJavaScript({

--- a/config/webpack/webpack.client.babel.ts
+++ b/config/webpack/webpack.client.babel.ts
@@ -177,7 +177,7 @@ export default {
         // eslintConfigFile: path.join(moduleRoot, '.eslintrc.js'),
         options: { caller: { target: 'web' } },
         sourceMaps,
-        transpiledLibs: [
+        transpiledLibs: production && [
           '@loadable',
           '@redux-saga',
           'create-color',
@@ -191,7 +191,7 @@ export default {
           'recharts',
           'redux/es',
         ],
-        nonTranspiledLibs: ['d3-array/src/cumsum.js'],
+        nonTranspiledLibs: production && ['d3-array/src/cumsum.js'],
       }),
 
       ...webpackLoadStyles({


### PR DESCRIPTION

## Related issues and PRs
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->
 - 

## Description
<!-- Goal of the pull request -->

This will make  package transpilation whitelist to only be processed in production mode.

This is necessary in order to account for the situation where the babel plugin of `@pmmmwh/react-refresh-webpack-plugin` adds variables inside a webworker, and which rely on globals that are not accessible in a webworker.

See discussion here:
https://github.com/neherlab/covid19_scenarios/pull/505#discussion_r410737067
https://github.com/neherlab/covid19_scenarios/pull/505#discussion_r411049698

As a workaround we disable the transpilation of `node_modules` completely in dev mode (the default behavior of babel loader), and only process additional packages in production, where fast refresh is disabled.

## Impacted Areas in the application
<!-- Components of the application that this PR will change -->

Build.

## Testing
<!-- Steps to test the changes proposed by this PR -->

:no_good: 
