### PR TITLE
feat: replace range sliders with pairs of spinboxes

### DIFF
--- a/src/components/Form/FormRangeSpinBox.tsx
+++ b/src/components/Form/FormRangeSpinBox.tsx
@@ -3,23 +3,12 @@ import React from 'react'
 
 import _ from 'lodash'
 
-import { FormikErrors, FormikTouched } from 'formik'
 import { Col, FormGroup, Row } from 'reactstrap'
+
+import type { FormSpinBoxProps } from './FormSpinBox'
 
 import FormLabel from './FormLabel'
 import { RangeSpinBox } from './RangeSpinBox'
-
-export interface FormRangeSpinBoxProps<T> {
-  identifier: string
-  label: string
-  help?: string | React.ReactNode
-  step?: number | string
-  min?: number
-  max?: number
-  pattern?: string
-  errors?: FormikErrors<T>
-  touched?: FormikTouched<T>
-}
 
 export function FormRangeSpinBox<T>({
   identifier,
@@ -31,7 +20,7 @@ export function FormRangeSpinBox<T>({
   pattern,
   errors,
   touched,
-}: FormRangeSpinBoxProps<T>) {
+}: FormSpinBoxProps<T>) {
   const isTouched = _.get(touched, identifier)
   const errorMessages = _.get(errors, identifier) as string[]
   const showError = errorMessages && isTouched

--- a/src/components/Form/FormRangeSpinBox.tsx
+++ b/src/components/Form/FormRangeSpinBox.tsx
@@ -1,13 +1,15 @@
+/* eslint-disable react/no-array-index-key */
 import React from 'react'
 
 import _ from 'lodash'
 
-import { Field, FormikErrors, FormikTouched } from 'formik'
-import { Col, FormGroup, InputGroup, Row } from 'reactstrap'
+import { FormikErrors, FormikTouched } from 'formik'
+import { Col, FormGroup, Row } from 'reactstrap'
 
 import FormLabel from './FormLabel'
+import { RangeSpinBox } from './RangeSpinBox'
 
-export interface FormSpinBoxProps<T> {
+export interface FormRangeSpinBoxProps<T> {
   identifier: string
   label: string
   help?: string | React.ReactNode
@@ -29,21 +31,10 @@ export function FormRangeSpinBox<T>({
   pattern,
   errors,
   touched,
-}: FormSpinBoxProps<T>) {
+}: FormRangeSpinBoxProps<T>) {
   const isTouched = _.get(touched, identifier)
-  const errorMessage = _.get(errors, identifier)
-  const showError = errorMessage && isTouched
-  const borderDanger = showError ? 'border-danger' : ''
-
-  function validate(value: number) {
-    let error
-    if (min && value < min) {
-      error = `The input cannot be less than ${min}`
-    } else if (max && value > max) {
-      error = `The input cannot be greater than ${max}`
-    }
-    return error
-  }
+  const errorMessages = _.get(errors, identifier) as string[]
+  const showError = errorMessages && isTouched
 
   return (
     <FormGroup inline className="my-0">
@@ -52,32 +43,22 @@ export function FormRangeSpinBox<T>({
           <FormLabel identifier={identifier} label={label} help={help} />
         </Col>
         <Col className="d-inline" xl={6}>
-          <InputGroup>
-            <Field
-              className={`form-control d-inline ${borderDanger}`}
-              id={identifier}
-              name={`${identifier}[0]`}
-              type="number"
-              step={step}
-              min={min}
-              max={max}
-              pattern={pattern}
-              validate={validate}
-            />
-            <span className="h-100 pt-2 px-1 text-bold">{'-'}</span>
-            <Field
-              className={`form-control d-inline  ${borderDanger}`}
-              id={identifier}
-              name={`${identifier}[1]`}
-              type="number"
-              step={step}
-              min={min}
-              max={max}
-              pattern={pattern}
-              validate={validate}
-            />
-          </InputGroup>
-          {showError ? <div className="text-danger">{errorMessage}</div> : null}
+          <RangeSpinBox
+            identifier={identifier}
+            step={step}
+            min={min}
+            max={max}
+            pattern={pattern}
+            errors={errors}
+            touched={touched}
+          />
+          {showError
+            ? errorMessages.map((errorMessage, i) => (
+                <div key={`${errorMessage} ([${i}])`} className="text-danger">
+                  {errorMessage}
+                </div>
+              ))
+            : null}
         </Col>
       </Row>
     </FormGroup>

--- a/src/components/Form/FormRangeSpinBox.tsx
+++ b/src/components/Form/FormRangeSpinBox.tsx
@@ -1,0 +1,85 @@
+import React from 'react'
+
+import _ from 'lodash'
+
+import { Field, FormikErrors, FormikTouched } from 'formik'
+import { Col, FormGroup, InputGroup, Row } from 'reactstrap'
+
+import FormLabel from './FormLabel'
+
+export interface FormSpinBoxProps<T> {
+  identifier: string
+  label: string
+  help?: string | React.ReactNode
+  step?: number | string
+  min?: number
+  max?: number
+  pattern?: string
+  errors?: FormikErrors<T>
+  touched?: FormikTouched<T>
+}
+
+export function FormRangeSpinBox<T>({
+  identifier,
+  label,
+  help,
+  step,
+  min,
+  max,
+  pattern,
+  errors,
+  touched,
+}: FormSpinBoxProps<T>) {
+  const isTouched = _.get(touched, identifier)
+  const errorMessage = _.get(errors, identifier)
+  const showError = errorMessage && isTouched
+  const borderDanger = showError ? 'border-danger' : ''
+
+  function validate(value: number) {
+    let error
+    if (min && value < min) {
+      error = `The input cannot be less than ${min}`
+    } else if (max && value > max) {
+      error = `The input cannot be greater than ${max}`
+    }
+    return error
+  }
+
+  return (
+    <FormGroup inline className="my-0">
+      <Row noGutters>
+        <Col xl={6}>
+          <FormLabel identifier={identifier} label={label} help={help} />
+        </Col>
+        <Col className="d-inline" xl={6}>
+          <InputGroup>
+            <Field
+              className={`form-control d-inline ${borderDanger}`}
+              id={identifier}
+              name={`${identifier}[0]`}
+              type="number"
+              step={step}
+              min={min}
+              max={max}
+              pattern={pattern}
+              validate={validate}
+            />
+            <span className="h-100 pt-2 px-1 text-bold">{'-'}</span>
+            <Field
+              className={`form-control d-inline  ${borderDanger}`}
+              id={identifier}
+              name={`${identifier}[1]`}
+              type="number"
+              step={step}
+              min={min}
+              max={max}
+              pattern={pattern}
+              validate={validate}
+            />
+          </InputGroup>
+          {showError ? <div className="text-danger">{errorMessage}</div> : null}
+        </Col>
+      </Row>
+    </FormGroup>
+  )
+}

--- a/src/components/Form/RangeSpinBox.tsx
+++ b/src/components/Form/RangeSpinBox.tsx
@@ -1,11 +1,9 @@
 import React from 'react'
 
-import _ from 'lodash'
-
-import { Field, FormikErrors, FormikTouched } from 'formik'
+import { FormikErrors, FormikTouched } from 'formik'
 import { InputGroup } from 'reactstrap'
 
-import { getFormikError } from '../../helpers/getFormikError'
+import { SpinBox } from './SpinBox'
 
 export interface FormSpinBoxProps<T> {
   identifier: string
@@ -18,17 +16,11 @@ export interface FormSpinBoxProps<T> {
 }
 
 export function RangeSpinBox<T>({ identifier, step, min, max, pattern, errors, touched }: FormSpinBoxProps<T>) {
-  const errorFirst = getFormikError({ errors, touched, identifier: `${identifier}[0]` })
-  const errorSecond = getFormikError({ errors, touched, identifier: `${identifier}[1]` })
-  const borderDangerFirst = errorFirst ? 'border-danger' : ''
-  const borderDangerSecond = errorSecond ? 'border-danger' : ''
-
   return (
     <InputGroup>
-      <Field
-        className={`form-control d-inline ${borderDangerFirst}`}
-        id={identifier}
-        name={`${identifier}[0]`}
+      <SpinBox
+        className="form-control d-inline"
+        identifier={`${identifier}[0]`}
         type="number"
         step={step}
         min={min}
@@ -36,10 +28,9 @@ export function RangeSpinBox<T>({ identifier, step, min, max, pattern, errors, t
         pattern={pattern}
       />
       <span className="h-100 pt-2 px-1 text-bold">{'-'}</span>
-      <Field
-        className={`form-control d-inline  ${borderDangerSecond}`}
-        id={identifier}
-        name={`${identifier}[1]`}
+      <SpinBox
+        className="form-control d-inline"
+        identifier={`${identifier}[1]`}
         type="number"
         step={step}
         min={min}

--- a/src/components/Form/RangeSpinBox.tsx
+++ b/src/components/Form/RangeSpinBox.tsx
@@ -5,7 +5,7 @@ import { InputGroup } from 'reactstrap'
 
 import { SpinBox } from './SpinBox'
 
-export interface FormSpinBoxProps<T> {
+export interface RangeSpinBoxProps<T> {
   identifier: string
   step?: number | string
   min?: number
@@ -15,7 +15,7 @@ export interface FormSpinBoxProps<T> {
   touched?: FormikTouched<T>
 }
 
-export function RangeSpinBox<T>({ identifier, step, min, max, pattern, errors, touched }: FormSpinBoxProps<T>) {
+export function RangeSpinBox<T>({ identifier, step, min, max, pattern, errors, touched }: RangeSpinBoxProps<T>) {
   return (
     <InputGroup>
       <SpinBox

--- a/src/components/Form/RangeSpinBox.tsx
+++ b/src/components/Form/RangeSpinBox.tsx
@@ -1,0 +1,49 @@
+import React from 'react'
+
+import _ from 'lodash'
+
+import { Field, FormikErrors, FormikTouched } from 'formik'
+import { InputGroup } from 'reactstrap'
+
+export interface FormSpinBoxProps<T> {
+  identifier: string
+  step?: number | string
+  min?: number
+  max?: number
+  pattern?: string
+  errors?: FormikErrors<T>
+  touched?: FormikTouched<T>
+}
+
+export function RangeSpinBox<T>({ identifier, step, min, max, pattern, errors, touched }: FormSpinBoxProps<T>) {
+  const isTouched = _.get(touched, identifier)
+  const errorMessage = _.get(errors, identifier)
+  const showError = errorMessage && isTouched
+  const borderDanger = showError ? 'border-danger' : ''
+
+  return (
+    <InputGroup>
+      <Field
+        className={`form-control d-inline ${borderDanger}`}
+        id={identifier}
+        name={`${identifier}[0]`}
+        type="number"
+        step={step}
+        min={min}
+        max={max}
+        pattern={pattern}
+      />
+      <span className="h-100 pt-2 px-1 text-bold">{'-'}</span>
+      <Field
+        className={`form-control d-inline  ${borderDanger}`}
+        id={identifier}
+        name={`${identifier}[1]`}
+        type="number"
+        step={step}
+        min={min}
+        max={max}
+        pattern={pattern}
+      />
+    </InputGroup>
+  )
+}

--- a/src/components/Form/RangeSpinBox.tsx
+++ b/src/components/Form/RangeSpinBox.tsx
@@ -5,6 +5,8 @@ import _ from 'lodash'
 import { Field, FormikErrors, FormikTouched } from 'formik'
 import { InputGroup } from 'reactstrap'
 
+import { getFormikError } from '../../helpers/getFormikError'
+
 export interface FormSpinBoxProps<T> {
   identifier: string
   step?: number | string
@@ -16,15 +18,15 @@ export interface FormSpinBoxProps<T> {
 }
 
 export function RangeSpinBox<T>({ identifier, step, min, max, pattern, errors, touched }: FormSpinBoxProps<T>) {
-  const isTouched = _.get(touched, identifier)
-  const errorMessage = _.get(errors, identifier)
-  const showError = errorMessage && isTouched
-  const borderDanger = showError ? 'border-danger' : ''
+  const errorFirst = getFormikError({ errors, touched, identifier: `${identifier}[0]` })
+  const errorSecond = getFormikError({ errors, touched, identifier: `${identifier}[1]` })
+  const borderDangerFirst = errorFirst ? 'border-danger' : ''
+  const borderDangerSecond = errorSecond ? 'border-danger' : ''
 
   return (
     <InputGroup>
       <Field
-        className={`form-control d-inline ${borderDanger}`}
+        className={`form-control d-inline ${borderDangerFirst}`}
         id={identifier}
         name={`${identifier}[0]`}
         type="number"
@@ -35,7 +37,7 @@ export function RangeSpinBox<T>({ identifier, step, min, max, pattern, errors, t
       />
       <span className="h-100 pt-2 px-1 text-bold">{'-'}</span>
       <Field
-        className={`form-control d-inline  ${borderDanger}`}
+        className={`form-control d-inline  ${borderDangerSecond}`}
         id={identifier}
         name={`${identifier}[1]`}
         type="number"

--- a/src/components/Form/SpinBox.tsx
+++ b/src/components/Form/SpinBox.tsx
@@ -1,0 +1,42 @@
+import React from 'react'
+
+import { Field, FormikErrors, FormikTouched } from 'formik'
+
+import { getFormikError } from '../../helpers/getFormikError'
+
+export interface FormSpinBoxProps<T> extends React.HTMLProps<HTMLInputElement> {
+  identifier: string
+  step?: number | string
+  min?: number
+  max?: number
+  pattern?: string
+  errors?: FormikErrors<T>
+  touched?: FormikTouched<T>
+}
+
+export function SpinBox<T>({
+  identifier,
+  step,
+  min,
+  max,
+  pattern,
+  errors,
+  touched,
+  ...restProps
+}: FormSpinBoxProps<T>) {
+  const errorMessage = getFormikError({ errors, touched, identifier: `${identifier}[0]` })
+  const borderDanger = errorMessage ? 'border-danger' : ''
+  return (
+    <Field
+      className={`form-control d-inline ${borderDanger}`}
+      id={identifier}
+      name={identifier}
+      type="number"
+      step={step}
+      min={min}
+      max={max}
+      pattern={pattern}
+      {...restProps}
+    />
+  )
+}

--- a/src/components/Main/Mitigation/MitigationTable.tsx
+++ b/src/components/Main/Mitigation/MitigationTable.tsx
@@ -1,7 +1,5 @@
 import React from 'react'
 
-import _ from 'lodash'
-
 import ReactResizeDetector from 'react-resize-detector'
 import { FastField, FieldArray, FieldArrayRenderProps, FormikErrors, FormikTouched, FormikValues } from 'formik'
 import { useTranslation } from 'react-i18next'

--- a/src/components/Main/Mitigation/MitigationTable.tsx
+++ b/src/components/Main/Mitigation/MitigationTable.tsx
@@ -16,25 +16,14 @@ import { suggestNextMitigationInterval } from '../../../algorithms/utils/createM
 import { MitigationDatePicker } from './MitigationDatePicker'
 import { RangeSpinBox } from '../../Form/RangeSpinBox'
 
+import { getFormikError } from '../../../helpers/getFormikError'
+
 import './MitigationTable.scss'
 
 export interface MitigationTableProps {
   mitigationIntervals: MitigationIntervals
   errors?: FormikErrors<FormikValues>
   touched?: FormikTouched<FormikValues>
-}
-
-export interface GetErrorParams {
-  identifier: string
-  errors?: FormikErrors<FormikValues>
-  touched?: FormikTouched<FormikValues>
-}
-
-export function getFormikError({ identifier, errors, touched }: GetErrorParams): string | undefined {
-  const isTouched = _.get(touched, identifier)
-  const errorMessage = _.get(errors, identifier)
-  const showError = errorMessage && isTouched
-  return showError ? (errorMessage as string) : undefined
 }
 
 export function MitigationTable({ mitigationIntervals, errors, touched }: MitigationTableProps) {

--- a/src/components/Main/Mitigation/MitigationTable.tsx
+++ b/src/components/Main/Mitigation/MitigationTable.tsx
@@ -5,7 +5,7 @@ import _ from 'lodash'
 import ReactResizeDetector from 'react-resize-detector'
 import { FastField, FieldArray, FieldArrayRenderProps, FormikErrors, FormikTouched, FormikValues } from 'formik'
 import { useTranslation } from 'react-i18next'
-import { Container, Col, Row, Button, FormGroup } from 'reactstrap'
+import { Button, Table } from 'reactstrap'
 
 import { FaTrash, FaPlus } from 'react-icons/fa'
 
@@ -14,8 +14,7 @@ import { MitigationInterval, MitigationIntervals } from '../../../algorithms/typ
 import { suggestNextMitigationInterval } from '../../../algorithms/utils/createMitigationInterval'
 
 import { MitigationDatePicker } from './MitigationDatePicker'
-
-import { RangeSlider } from '../../Form/FormRangeSlider'
+import { RangeSpinBox } from '../../Form/RangeSpinBox'
 
 import './MitigationTable.scss'
 
@@ -54,24 +53,36 @@ export function MitigationTable({ mitigationIntervals, errors, touched }: Mitiga
                 your community.
               </p>
               <p>Each measure consists of name, start/end date, and an effectiveness in %.</p>
-              <div className="w-100">
-                {mitigationIntervals.map((interval: MitigationInterval, index: number) => {
-                  if (!interval) {
-                    return null
-                  }
-                  return (
-                    <MitigationIntervalComponent
-                      key={interval.id}
-                      interval={interval}
-                      index={index}
-                      arrayHelpers={arrayHelpers}
-                      width={width || 0}
-                      errors={errors}
-                      touched={touched}
-                    />
-                  )
-                })}
-              </div>
+
+              <Table>
+                <thead>
+                  <tr>
+                    <th>{`Intervention name`}</th>
+                    <th>{`Date range`}</th>
+                    <th>{`Transmission reduction`}</th>
+                    <th />
+                  </tr>
+                </thead>
+
+                <tbody>
+                  {mitigationIntervals.map((interval: MitigationInterval, index: number) => {
+                    if (!interval) {
+                      return null
+                    }
+                    return (
+                      <MitigationIntervalComponent
+                        key={interval.id}
+                        interval={interval}
+                        index={index}
+                        arrayHelpers={arrayHelpers}
+                        width={width || 0}
+                        errors={errors}
+                        touched={touched}
+                      />
+                    )
+                  })}
+                </tbody>
+              </Table>
               <div className="table-controls">
                 <Button
                   type="button"
@@ -123,52 +134,46 @@ function MitigationIntervalComponent({
   })
 
   return (
-    <FormGroup>
-      <div
-        className={`mitigation-interval ${
-          // eslint-disable-next-line unicorn/no-nested-ternary
-          width && width <= 325 ? 'very-narrow' : width && width <= 580 ? 'narrow' : 'wide'
-        }`}
-      >
-        <div className="inputs">
-          <Container fluid>
-            <Row noGutters>
-              <Col sm md lg xl="auto">
-                <FastField
-                  className={`name form-control ${nameError ? 'border-danger' : ''}`}
-                  id={`containment.mitigationIntervals[${index}].name`}
-                  name={`containment.mitigationIntervals[${index}].name`}
-                  type="text"
-                />
-              </Col>
-              <Col sm md lg xl="auto">
-                <MitigationDatePicker
-                  identifier={`containment.mitigationIntervals[${index}].timeRange`}
-                  value={interval.timeRange}
-                  allowPast
-                />
-              </Col>
-              <Col>
-                <RangeSlider
-                  identifier={`containment.mitigationIntervals[${index}].mitigationValue`}
-                  step={0.1}
-                  min={0}
-                  max={100}
-                />
-              </Col>
-            </Row>
-          </Container>
+    <>
+      <tr>
+        <td>
+          <FastField
+            className={`form-control ${nameError ? 'border-danger' : ''}`}
+            id={`containment.mitigationIntervals[${index}].name`}
+            name={`containment.mitigationIntervals[${index}].name`}
+            type="text"
+          />
+        </td>
+        <td>
+          <MitigationDatePicker
+            identifier={`containment.mitigationIntervals[${index}].timeRange`}
+            value={interval.timeRange}
+            allowPast
+          />
+        </td>
+        <td>
+          <RangeSpinBox
+            identifier={`containment.mitigationIntervals[${index}].mitigationValue`}
+            step={0.1}
+            min={0}
+            max={100}
+          />
+        </td>
+        <td>
+          <div className="item-controls">
+            <Button type="button" onClick={() => arrayHelpers.remove(index)}>
+              <FaTrash />
+            </Button>
+          </div>
+        </td>
+      </tr>
+
+      <tr>
+        <div className="w-100">
+          {nameError && <p className="my-0 text-right text-danger">{`${t('Intervention name')}: ${nameError}`}</p>}
+          {valueError && <p className="my-0 text-right text-danger">{`${t('Mitigation strength')}: ${valueError}`}</p>}
         </div>
-        <div className="item-controls">
-          <Button type="button" onClick={() => arrayHelpers.remove(index)}>
-            <FaTrash />
-          </Button>
-        </div>
-      </div>
-      <div className="w-100">
-        {nameError && <p className="my-0 text-right text-danger">{`${t('Intervention name')}: ${nameError}`}</p>}
-        {valueError && <p className="my-0 text-right text-danger">{`${t('Mitigation strength')}: ${valueError}`}</p>}
-      </div>
-    </FormGroup>
+      </tr>
+    </>
   )
 }

--- a/src/components/Main/Scenario/ScenarioCardEpidemiological.tsx
+++ b/src/components/Main/Scenario/ScenarioCardEpidemiological.tsx
@@ -6,8 +6,8 @@ import { FormikErrors, FormikTouched, FormikValues } from 'formik'
 
 import { CardWithoutDropdown } from '../../Form/CardWithoutDropdown'
 import { FormDropdown } from '../../Form/FormDropdown'
+import { FormRangeSpinBox } from '../../Form/FormRangeSpinBox'
 import { FormSpinBox } from '../../Form/FormSpinBox'
-import { RangeSlider } from '../../Form/FormRangeSlider'
 
 const months = moment.months()
 const monthOptions = months.map((month, i) => ({ value: i, label: month }))
@@ -32,15 +32,14 @@ function ScenarioCardEpidemiological({ errors, touched }: ScenarioCardEpidemiolo
         'Epidemiological parameters specifing growth rate, seasonal variation, and duration of hospital stay. The presets are combinations of speed and geography (speed/region).',
       )}
     >
-      <RangeSlider
+      <FormRangeSpinBox
         identifier="epidemiological.r0"
         label={`${t('Annual average')} R\u2080`}
         help={t(
           'Average number of secondary infections per case. When R0 varies throughout the year (seasonal forcing), this value is the mean R0.',
         )}
-        step={0.1}
+        step={0.01}
         min={0.5}
-        max={6}
         errors={errors}
         touched={touched}
       />

--- a/src/helpers/getFormikError.ts
+++ b/src/helpers/getFormikError.ts
@@ -1,0 +1,16 @@
+import _ from 'lodash'
+
+import { FormikErrors, FormikTouched, FormikValues } from 'formik'
+
+export interface GetErrorParams {
+  identifier: string
+  errors?: FormikErrors<FormikValues>
+  touched?: FormikTouched<FormikValues>
+}
+
+export function getFormikError({ identifier, errors, touched }: GetErrorParams): string | undefined {
+  const isTouched = _.get(touched, identifier)
+  const errorMessage = _.get(errors, identifier)
+  const showError = errorMessage && isTouched
+  return showError ? (errorMessage as string) : undefined
+}


### PR DESCRIPTION
## Related issues and PRs
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->
 - Contributes to #580 

## Description
<!-- Goal of the pull request -->

This explores the user experience with 
 - a pair of spinboxes as a mean to set ranges of numbers for the parameter uncertainty feature
 - table layout for the mitigation widget

## Impacted Areas in the application
<!-- Components of the application that this PR will change -->

UX

## Testing
<!-- Steps to test the changes proposed by this PR -->
