### PR TITLE
Remove duplicated 'immer' in webpack transpiledLibs.

### DIFF
--- a/config/webpack/webpack.client.babel.ts
+++ b/config/webpack/webpack.client.babel.ts
@@ -184,7 +184,6 @@ export default {
           'd3-array',
           'delay',
           'immer',
-          'immer',
           'lodash',
           'p-min-delay',
           'react-router',


### PR DESCRIPTION
## Related issues and PRs

No relation.

## Description

Removes the duplicated `'immer'` listed in the webpack config `transpiledLibs` array. The duplication is harmless but unnecessary. Probably a merge artifact.

## Impacted Areas in the application

Production Webpack bundling.

## Testing

`yarn prod:build`