### PR TITLE
feat: set spinbox minimum to 10 runs

### DIFF
--- a/schemas/Scenarios.yml
+++ b/schemas/Scenarios.yml
@@ -162,7 +162,7 @@ definitions:
       numberStochasticRuns:
         type: integer
         multipleOf: 1
-        minimum: 1
+        minimum: 10
         maximum: 100
 
   DateRange:

--- a/src/components/Main/Scenario/ScenarioCardPopulation.tsx
+++ b/src/components/Main/Scenario/ScenarioCardPopulation.tsx
@@ -119,7 +119,7 @@ function ScenarioCardPopulation({ errors, touched }: ScenarioCardPopulationProps
           'Perform multiple runs, to account for the uncertainty of parameters. More runs result in more accurate simulation, but take more time to finish.',
         )}
         step={1}
-        min={1}
+        min={10}
         errors={errors}
         touched={touched}
       />

--- a/src/components/Main/validation/schema.ts
+++ b/src/components/Main/validation/schema.ts
@@ -10,7 +10,7 @@ const ageRegions = [...ageDistributionNames, CUSTOM_COUNTRY_NAME]
 const MSG_REQUIRED = i18next.t('Value is required')
 const MSG_NON_NEGATIVE = i18next.t('Should be non-negative (or zero)')
 const MSG_POSITIVE = i18next.t('Should be strictly positive (non-zero)')
-const MSG_AT_LEAST_ONE = i18next.t('Should be at least one')
+const MSG_AT_LEAST_TEN = i18next.t('Should be at least ten')
 const MSG_AT_LEAST_ONE_DAY = i18next.t('Should be at least one day or greater')
 const MSG_INTEGER = i18next.t('Should be a whole number')
 const MSG_TOO_MANY_RUNS = i18next.t('Too many runs')
@@ -78,7 +78,7 @@ export const schema = yup.object().shape({
       .number()
       .integer(MSG_INTEGER)
       .required(MSG_REQUIRED)
-      .min(1, MSG_AT_LEAST_ONE)
+      .min(10, MSG_AT_LEAST_TEN)
       .max(100, MSG_TOO_MANY_RUNS),
 
     simulationTimeRange: dateRange().required(MSG_REQUIRED),


### PR DESCRIPTION
## Related issues and PRs
 - Related to issue #581, #582  
 - "spinbox limit min to 10"

## Description
Set spinbox minimum value to 10 in Scenarios.yml; modified error msg in schema.ts to "Should be at least ten."

## Impacted Areas in the application
schemas/Scenarios.yml
src/components/Main/validation/schema.ts


