### PR TITLE
Feat/cumulative simulation cases

### DIFF
--- a/src/components/Main/Results/ChartCommon.ts
+++ b/src/components/Main/Results/ChartCommon.ts
@@ -22,6 +22,7 @@ export const DATA_POINTS = {
   NewCases: 'newCases',
   HospitalBeds: 'hospitalBeds',
   ICUbeds: 'ICUbeds',
+  CumulativeSim: 'cumulativesim',
   /* Observed */
   ObservedDeaths: 'observedDeaths',
   ObservedCases: 'cases',
@@ -42,10 +43,12 @@ export const colors = {
   [DATA_POINTS.NewCases]: '#fdbf6f',
   [DATA_POINTS.HospitalBeds]: '#bbbbbb',
   [DATA_POINTS.ICUbeds]: '#cccccc',
+  [DATA_POINTS.CumulativeSim]: '#0000ff',
 }
 
 export const linesToPlot: LineProps[] = [
   { key: DATA_POINTS.Susceptible, color: colors.susceptible, name: 'Susceptible', legendType: 'line' },
+  { key: DATA_POINTS.CumulativeSim, color: colors.cumulativesim, name: 'Cumulative cases (simulation)', legendType: 'line' },
   { key: DATA_POINTS.Recovered, color: colors.recovered, name: 'Recovered', legendType: 'line' },
   { key: DATA_POINTS.Infectious, color: colors.infectious, name: 'Infectious', legendType: 'line' },
   { key: DATA_POINTS.Severe, color: colors.severe, name: 'Severely ill', legendType: 'line' },
@@ -61,6 +64,12 @@ export const areasToPlot: LineProps[] = [
     key: `${DATA_POINTS.Susceptible}Area`,
     color: colors.susceptible,
     name: 'Susceptible uncertainty',
+    legendType: 'none',
+  },
+  {
+    key: `${DATA_POINTS.CumulativeSim}Area`,
+    color: colors.cumulativesim,
+    name: 'Cumulative cases (simulation) uncertainty',
     legendType: 'none',
   },
   {

--- a/src/components/Main/Results/DeterministicLinePlot.tsx
+++ b/src/components/Main/Results/DeterministicLinePlot.tsx
@@ -132,10 +132,11 @@ export function DeterministicLinePlot({
 
   const { mitigationIntervals } = mitigation
 
+  const nPopulation  = verifyPositive(params.population.populationServed)
   const nHospitalBeds = verifyPositive(params.population.hospitalBeds)
   const nICUBeds = verifyPositive(params.population.ICUBeds)
 
-  const nonEmptyCaseCounts = caseCounts?.filter((d) => d.cases || d.deaths || d.icu || d.hospitalized)
+  const nonEmptyCaseCounts = caseCounts?.filter((d) => d.cases || d.deaths || d.icu || d.hospitalized || d.simulation)
 
   const [newEmpiricalCases, caseTimeWindow] = computeNewEmpiricalCases(
     params.epidemiological.infectiousPeriod,
@@ -145,6 +146,7 @@ export function DeterministicLinePlot({
 
   const countObservations = {
     cases: nonEmptyCaseCounts?.filter((d) => d.cases).length ?? 0,
+    //##simulation: nonEmptyCaseCounts?.filter((d) => d.simulation).length ?? 0,
     ICU: nonEmptyCaseCounts?.filter((d) => d.icu).length ?? 0,
     observedDeaths: nonEmptyCaseCounts?.filter((d) => d.deaths).length ?? 0,
     newCases: nonEmptyCaseCounts?.filter((_0, i) => newEmpiricalCases[i]).length ?? 0,
@@ -154,6 +156,7 @@ export function DeterministicLinePlot({
   const observations =
     nonEmptyCaseCounts?.map((d, i) => ({
       time: new Date(d.time).getTime(),
+      //##simulation: enabledPlots.includes(DATA_POINTS.ObservedSimulatedCases) ? d.simuation || undefined : undefined,
       cases: enabledPlots.includes(DATA_POINTS.ObservedCases) ? d.cases || undefined : undefined,
       observedDeaths: enabledPlots.includes(DATA_POINTS.ObservedDeaths) ? d.deaths || undefined : undefined,
       currentHospitalized: enabledPlots.includes(DATA_POINTS.ObservedHospitalized)
@@ -170,6 +173,9 @@ export function DeterministicLinePlot({
   const plotData = [
     ...data.trajectory.mean.map((x, i) => ({
       time: x.time,
+      cumulativesim: enabledPlots.includes(DATA_POINTS.CumulativeSim)
+        ? verifyPositive(nPopulation - x.current.susceptible.total)
+        : undefined,
       susceptible: enabledPlots.includes(DATA_POINTS.Susceptible)
         ? verifyPositive(x.current.susceptible.total)
         : undefined,
@@ -195,6 +201,9 @@ export function DeterministicLinePlot({
       // Error bars
       susceptibleArea: enabledPlots.includes(DATA_POINTS.Susceptible)
         ? [verifyPositive(lower[i].current.susceptible.total), verifyPositive(upper[i].current.susceptible.total)]
+        : undefined,
+      cumulativesimArea: enabledPlots.includes(DATA_POINTS.CumulativeSim)
+        ? [verifyPositive(nPopulation - upper[i].current.susceptible.total), verifyPositive(nPopulation - lower[i].current.susceptible.total)]
         : undefined,
       infectiousArea: enabledPlots.includes(DATA_POINTS.Infectious)
         ? [verifyPositive(lower[i].current.infectious.total), verifyPositive(upper[i].current.infectious.total)]

--- a/src/components/Main/Results/DeterministicLinePlot.tsx
+++ b/src/components/Main/Results/DeterministicLinePlot.tsx
@@ -136,7 +136,7 @@ export function DeterministicLinePlot({
   const nHospitalBeds = verifyPositive(params.population.hospitalBeds)
   const nICUBeds = verifyPositive(params.population.ICUBeds)
 
-  const nonEmptyCaseCounts = caseCounts?.filter((d) => d.cases || d.deaths || d.icu || d.hospitalized || d.simulation)
+  const nonEmptyCaseCounts = caseCounts?.filter((d) => d.cases || d.deaths || d.icu || d.hospitalized)
 
   const [newEmpiricalCases, caseTimeWindow] = computeNewEmpiricalCases(
     params.epidemiological.infectiousPeriod,
@@ -146,7 +146,6 @@ export function DeterministicLinePlot({
 
   const countObservations = {
     cases: nonEmptyCaseCounts?.filter((d) => d.cases).length ?? 0,
-    //##simulation: nonEmptyCaseCounts?.filter((d) => d.simulation).length ?? 0,
     ICU: nonEmptyCaseCounts?.filter((d) => d.icu).length ?? 0,
     observedDeaths: nonEmptyCaseCounts?.filter((d) => d.deaths).length ?? 0,
     newCases: nonEmptyCaseCounts?.filter((_0, i) => newEmpiricalCases[i]).length ?? 0,
@@ -156,7 +155,6 @@ export function DeterministicLinePlot({
   const observations =
     nonEmptyCaseCounts?.map((d, i) => ({
       time: new Date(d.time).getTime(),
-      //##simulation: enabledPlots.includes(DATA_POINTS.ObservedSimulatedCases) ? d.simuation || undefined : undefined,
       cases: enabledPlots.includes(DATA_POINTS.ObservedCases) ? d.cases || undefined : undefined,
       observedDeaths: enabledPlots.includes(DATA_POINTS.ObservedDeaths) ? d.deaths || undefined : undefined,
       currentHospitalized: enabledPlots.includes(DATA_POINTS.ObservedHospitalized)


### PR DESCRIPTION
## Related issues and PRs
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->
 - Related to issue #517 

## Description
<!-- Goal of the pull request -->
Add a new line to the results plot to show the cumulative cases in the simulation. This is calculated using population - current susceptible

## Impacted Areas in the application
<!-- Components of the application that this PR will change -->
src/components/Main/Results/DeterministicLinePlot.tsx 
src/components/Main/Results/ChartCommon.ts

## Testing
<!-- Steps to test the changes proposed by this PR -->
Check the results plot and compare with population/ susceptibility values