### PR TITLE
Remove unncessary console.error

### DIFF
--- a/src/workers/algorithm/index.ts
+++ b/src/workers/algorithm/index.ts
@@ -20,7 +20,6 @@ export async function run(...args) {
 
     worker.addEventListener('error', (error) => {
       reject(error)
-      console.error('Worker error:', error)
     })
 
     worker.postMessage(args)


### PR DESCRIPTION
## Related issues and PRs

#612 reveals the issue, and #505 is the original implementation.   

## Description

There is an unnecessary console.error() log in the webworker. This PR removes the extra call.

## Impacted Areas in the application

Webworker error logging. 

## Testing

Difficult to test without an error, but #612 provides and indirect example of the behavior.
