### PR TITLE
fix: allow for population of 0 in age distribution

### DIFF
--- a/schemas/AgeDistributionDatum.yml
+++ b/schemas/AgeDistributionDatum.yml
@@ -15,4 +15,4 @@ properties:
     $ref: 'AgeGroup#'
 
   population:
-    $ref: 'IntegerPositive#'
+    $ref: 'IntegerNonNegative#'


### PR DESCRIPTION
## Related issues and PRs
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->
 - 

## Description
<!-- Goal of the pull request -->

Allows 0 for population value in age distribution schema

## Impacted Areas in the application
<!-- Components of the application that this PR will change -->


## Testing
<!-- Steps to test the changes proposed by this PR -->
