### PR TITLE
feat: preserve user-provided scenario name on parameter change

### DIFF
--- a/src/components/Main/HandleInitialState.tsx
+++ b/src/components/Main/HandleInitialState.tsx
@@ -34,6 +34,7 @@ function deserializeScenarioFromURL(location: Location) {
   return {
     scenarios: scenarioNames,
     current: data.scenarioName,
+    shouldRenameOnEdits: false,
     data: data.scenario,
     ageDistribution: data.ageDistribution,
   }

--- a/src/components/Main/ScenarioLoader/ScenarioLoaderUploader.tsx
+++ b/src/components/Main/ScenarioLoader/ScenarioLoaderUploader.tsx
@@ -86,6 +86,7 @@ export function ScenarioLoaderUploader({ scenarioDispatch, setSeverity, close }:
     scenarioDispatch(
       setStateData({
         current: params.scenarioName,
+        shouldRenameOnEdits: false,
         data: params.scenario,
         ageDistribution: params.ageDistribution,
       }),

--- a/src/components/Main/state/actions.ts
+++ b/src/components/Main/state/actions.ts
@@ -1,13 +1,15 @@
+import { StrictOmit } from 'ts-essentials'
 import actionCreatorFactory from 'typescript-fsa'
 
 import type {
   AgeDistributionDatum,
-  ScenarioDatum,
   ScenarioDatumEpidemiological,
   ScenarioDatumMitigation,
   ScenarioDatumPopulation,
   ScenarioDatumSimulation,
 } from '../../../algorithms/types/Param.types'
+
+import type { State } from './state'
 
 const action = actionCreatorFactory('SCENARIO')
 
@@ -38,11 +40,7 @@ export interface SetAgeDistributionData {
   data: AgeDistributionDatum[]
 }
 
-export interface SetStateData {
-  current: string
-  data: ScenarioDatum
-  ageDistribution: AgeDistributionDatum[]
-}
+export type SetStateData = StrictOmit<State, 'scenarios'>
 
 export const setPopulationData = action<SetPopulationData>('SET_POPULATION_DATA')
 export const setEpidemiologicalData = action<SetEpidemiologicalData>('SET_EPIDEMIOLOGICAL_DATA')

--- a/src/components/Main/state/reducer.ts
+++ b/src/components/Main/state/reducer.ts
@@ -18,10 +18,14 @@ import {
 import { getScenario } from './getScenario'
 import { getAgeDistribution } from './getAgeDistribution'
 
-import { CUSTOM_SCENARIO_NAME, CUSTOM_COUNTRY_NAME, defaultScenarioState } from './state'
+import { CUSTOM_COUNTRY_NAME, defaultScenarioState, State } from './state'
 
-function maybeAdd<T>(where: T[], what: T): T[] {
-  return _.uniq([...where, what])
+export function maybeChangeTitle(state: State) {
+  let name = state.current
+  if (state.shouldRenameOnEdits) {
+    name = `${name} (edited)`
+  }
+  return name
 }
 
 /**
@@ -45,24 +49,23 @@ export const scenarioReducer = reducerWithInitialState(defaultScenarioState)
   .withHandling(
     immerCase(renameCurrentScenario, (draft, { name }) => {
       draft.current = name
+      draft.shouldRenameOnEdits = false
     }),
   )
 
   .withHandling(
     immerCase(setScenario, (draft, { name }) => {
-      draft.scenarios = maybeAdd(draft.scenarios, CUSTOM_SCENARIO_NAME)
-      draft.current = name
-      if (name !== CUSTOM_SCENARIO_NAME) {
-        draft.data = _.cloneDeep(getScenario(name))
-        draft.ageDistribution = getAgeDistribution(draft.data.population.ageDistributionName)
-      }
+      draft.current = maybeChangeTitle(draft)
+      draft.shouldRenameOnEdits = false
+      draft.data = _.cloneDeep(getScenario(name))
+      draft.ageDistribution = getAgeDistribution(draft.data.population.ageDistributionName)
     }),
   )
 
   .withHandling(
     immerCase(setPopulationData, (draft, { data }) => {
-      draft.scenarios = maybeAdd(draft.scenarios, CUSTOM_SCENARIO_NAME)
-      draft.current = CUSTOM_SCENARIO_NAME
+      draft.current = maybeChangeTitle(draft)
+      draft.shouldRenameOnEdits = false
       draft.data.population = _.cloneDeep(data)
       if (draft.data.population.ageDistributionName !== CUSTOM_COUNTRY_NAME) {
         draft.ageDistribution = getAgeDistribution(draft.data.population.ageDistributionName)
@@ -72,41 +75,41 @@ export const scenarioReducer = reducerWithInitialState(defaultScenarioState)
 
   .withHandling(
     immerCase(setEpidemiologicalData, (draft, { data }) => {
-      draft.scenarios = maybeAdd(draft.scenarios, CUSTOM_SCENARIO_NAME)
-      draft.current = CUSTOM_SCENARIO_NAME
+      draft.current = maybeChangeTitle(draft)
+      draft.shouldRenameOnEdits = false
       draft.data.epidemiological = _.cloneDeep(data)
     }),
   )
 
   .withHandling(
     immerCase(setMitigationData, (draft, { data }) => {
-      draft.scenarios = maybeAdd(draft.scenarios, CUSTOM_SCENARIO_NAME)
-      draft.current = CUSTOM_SCENARIO_NAME
+      draft.current = maybeChangeTitle(draft)
+      draft.shouldRenameOnEdits = false
       draft.data.mitigation.mitigationIntervals = _.cloneDeep(data.mitigationIntervals)
     }),
   )
 
   .withHandling(
     immerCase(setSimulationData, (draft, { data }) => {
-      draft.scenarios = maybeAdd(draft.scenarios, CUSTOM_SCENARIO_NAME)
-      draft.current = CUSTOM_SCENARIO_NAME
+      draft.current = maybeChangeTitle(draft)
+      draft.shouldRenameOnEdits = false
       draft.data.simulation = _.cloneDeep(data)
     }),
   )
 
   .withHandling(
     immerCase(setAgeDistributionData, (draft, { data }) => {
-      draft.scenarios = maybeAdd(draft.scenarios, CUSTOM_SCENARIO_NAME)
-      draft.current = CUSTOM_SCENARIO_NAME
+      draft.current = maybeChangeTitle(draft)
+      draft.shouldRenameOnEdits = false
       draft.ageDistribution = data
       draft.data.population.ageDistributionName = CUSTOM_COUNTRY_NAME
     }),
   )
 
   .withHandling(
-    immerCase(setStateData, (draft, { current, data, ageDistribution }) => {
-      draft.scenarios = maybeAdd(draft.scenarios, current)
+    immerCase(setStateData, (draft, { current, data, shouldRenameOnEdits, ageDistribution }) => {
       draft.current = current
+      draft.shouldRenameOnEdits = shouldRenameOnEdits
       draft.data = data
       draft.ageDistribution = ageDistribution
     }),

--- a/src/components/Main/state/reducer.ts
+++ b/src/components/Main/state/reducer.ts
@@ -55,8 +55,8 @@ export const scenarioReducer = reducerWithInitialState(defaultScenarioState)
 
   .withHandling(
     immerCase(setScenario, (draft, { name }) => {
-      draft.current = maybeChangeTitle(draft)
-      draft.shouldRenameOnEdits = false
+      draft.current = name
+      draft.shouldRenameOnEdits = true
       draft.data = _.cloneDeep(getScenario(name))
       draft.ageDistribution = getAgeDistribution(draft.data.population.ageDistributionName)
     }),

--- a/src/components/Main/state/state.ts
+++ b/src/components/Main/state/state.ts
@@ -1,4 +1,3 @@
-import i18next from 'i18next'
 import { scenarioNames, getScenario } from './getScenario'
 import { getAgeDistribution } from './getAgeDistribution'
 import { ScenarioDatum, AgeDistributionDatum } from '../../../algorithms/types/Param.types'
@@ -6,13 +5,13 @@ import { ScenarioDatum, AgeDistributionDatum } from '../../../algorithms/types/P
 export interface State {
   scenarios: string[]
   current: string
+  shouldRenameOnEdits: boolean
   data: ScenarioDatum
   ageDistribution: AgeDistributionDatum[]
 }
 
 // TODO: Add a default category to export
 export const DEFAULT_OVERALL_SCENARIO_NAME = 'United States of America'
-export const CUSTOM_SCENARIO_NAME = i18next.t('Custom')
 export const CUSTOM_COUNTRY_NAME = 'Custom'
 export const NONE_COUNTRY_NAME = 'None'
 
@@ -23,6 +22,7 @@ const defaultScenarioData = getScenario(defaultScenarioName)
 export const defaultScenarioState: State = {
   scenarios: scenarioNames,
   current: defaultScenarioName,
+  shouldRenameOnEdits: true,
   data: defaultScenarioData,
   ageDistribution: getAgeDistribution(defaultScenarioData.population.ageDistributionName),
 }


### PR DESCRIPTION

 Related issues and PRs
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->
 - Fixes #653

## Description
<!-- Goal of the pull request -->

This adds a boolean flag to the state and changes scenario state reducer logic such that the user-provided scenario title is preserved at all times.

## Impacted Areas in the application
<!-- Components of the application that this PR will change -->


## Testing
<!-- Steps to test the changes proposed by this PR -->
