### PR TITLE
Ensure severity table is restored from URL

### DIFF
--- a/src/components/Main/HandleInitialState.tsx
+++ b/src/components/Main/HandleInitialState.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 
 import { isEqual, isEmpty } from 'lodash'
 
@@ -20,13 +20,19 @@ import { getSeverityDistribution } from './state/getSeverityDistribution'
 export const DEFAULT_SEVERITY_DISTRIBUTION = 'China CDC'
 const severityDistribution = getSeverityDistribution(DEFAULT_SEVERITY_DISTRIBUTION)
 
-const defaultSuperState = {
+interface SuperState {
+  scenarioState: State
+  severityName: string
+  severityTable: SeverityDistributionDatum[]
+}
+
+const defaultSuperState: SuperState = {
   scenarioState: defaultScenarioState,
   severityName: DEFAULT_SEVERITY_DISTRIBUTION,
   severityTable: severityDistribution,
 }
 
-function deserializeScenarioFromURL(location: Location) {
+function deserializeScenarioFromURL(location: Location): SuperState {
   const search = location?.search
   if (!search || isEmpty(search)) {
     return defaultSuperState
@@ -65,13 +71,14 @@ export interface HandleInitialStateProps {
 }
 
 function HandleInitialState({ location, push, component: Component }: HandleInitialStateProps) {
-  const { scenarioState, severityName, severityTable } = deserializeScenarioFromURL(location)
+  const [{ scenarioState, severityName, severityTable }] = useState<SuperState>(deserializeScenarioFromURL(location))
 
   useEffect(() => {
     if (location.search) {
       push({ pathname: location.pathname, search: '' })
     }
-  }, [location.pathname, location.search, push])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   return (
     <Component

--- a/src/components/Main/HandleInitialState.tsx
+++ b/src/components/Main/HandleInitialState.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useEffect } from 'react'
 
 import { isEqual, isEmpty } from 'lodash'
 
@@ -20,23 +20,31 @@ import { getSeverityDistribution } from './state/getSeverityDistribution'
 export const DEFAULT_SEVERITY_DISTRIBUTION = 'China CDC'
 const severityDistribution = getSeverityDistribution(DEFAULT_SEVERITY_DISTRIBUTION)
 
+const defaultSuperState = {
+  scenarioState: defaultScenarioState,
+  severityName: DEFAULT_SEVERITY_DISTRIBUTION,
+  severityTable: severityDistribution,
+}
+
 function deserializeScenarioFromURL(location: Location) {
   const search = location?.search
   if (!search || isEmpty(search)) {
-    return defaultScenarioState
+    return defaultSuperState
   }
 
   const data = dataFromUrl(search)
   if (!data) {
-    return defaultScenarioState
+    return defaultSuperState
   }
 
-  return {
+  const scenarioState: State = {
     scenarios: scenarioNames,
     current: data.scenarioName,
     data: data.scenario,
     ageDistribution: data.ageDistribution,
   }
+
+  return { scenarioState, severityName: data.severityName, severityTable: data.severity }
 }
 
 interface InitialState {
@@ -57,7 +65,7 @@ export interface HandleInitialStateProps {
 }
 
 function HandleInitialState({ location, push, component: Component }: HandleInitialStateProps) {
-  const [scenarioState] = useState<State>(deserializeScenarioFromURL(location))
+  const { scenarioState, severityName, severityTable } = deserializeScenarioFromURL(location)
 
   useEffect(() => {
     if (location.search) {
@@ -69,8 +77,8 @@ function HandleInitialState({ location, push, component: Component }: HandleInit
     <Component
       initialState={{
         scenarioState,
-        severityName: DEFAULT_SEVERITY_DISTRIBUTION,
-        severityTable: severityDistribution,
+        severityName,
+        severityTable,
         isDefault: isEqual(scenarioState, defaultScenarioState),
       }}
     />


### PR DESCRIPTION
## Related issues and PRs
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->
 - 

## Description
<!-- Goal of the pull request -->

This makes sure that the severity table is restored from the shared URL.
The issue was that the severity data was deserialized, but ignored and default data was loaded instead.

## Impacted Areas in the application
<!-- Components of the application that this PR will change -->

UI, initial state

## Testing
<!-- Steps to test the changes proposed by this PR -->
