### PR TITLE
fix: hide "expand" results button on lg screens and smaller

### DIFF
--- a/src/components/Main/Results/ResultsCard.tsx
+++ b/src/components/Main/Results/ResultsCard.tsx
@@ -113,7 +113,7 @@ function ResultsCardFunction({
         className="card--main card--results"
         label={
           <h2 className="p-0 m-0 text-truncate d-flex align-items-center" data-testid="ResultsCardTitle">
-            <Button onClick={toggleResultsMaximized} className="btn-dark mr-2">
+            <Button onClick={toggleResultsMaximized} className="btn-dark mr-2 d-none d-xl-block">
               {areResultsMaximized ? <FiChevronRight /> : <FiChevronLeft />}
             </Button>
             <span>{t('Results')}</span>


### PR DESCRIPTION
## Related issues and PRs
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->
 - 

## Description
<!-- Goal of the pull request -->

Hides "expand" results button on lg screens and smaller, as expand function does not work there (not enough space)

## Impacted Areas in the application
<!-- Components of the application that this PR will change -->


## Testing
<!-- Steps to test the changes proposed by this PR -->
