### PR TITLE
fix: fix crash when running snyk protect

### DIFF
--- a/package.json
+++ b/package.json
@@ -375,6 +375,7 @@
     "**/core-js": "3.6.4",
     "**/json3": "link:3rdparty/__empty-module",
     "**/left-pad": "link:3rdparty/__empty-module",
+    "jszip": "3.4.0",
     "moment": "2.25.3",
     "node-sass": "link:node_modules/sass",
     "svgo": "1.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5511,7 +5511,7 @@ core-js-pure@^3.0.0:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.6.5.tgz#c79e75f5e38dbc85a662d91eea52b8256d53b813"
   integrity sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==
 
-core-js@3.6.4, core-js@^2.4.1, core-js@^3.2.0, core-js@^3.2.1, core-js@^3.4.2, core-js@~2.3.0:
+core-js@3.6.4, core-js@^2.4.1, core-js@^3.2.0, core-js@^3.2.1, core-js@^3.4.2:
   version "3.6.4"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.4.tgz#440a83536b458114b9cb2ac1580ba377dc470647"
   integrity sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw==
@@ -7032,11 +7032,6 @@ es6-promise@^4.0.3:
   version "4.2.8"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a"
   integrity sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==
-
-es6-promise@~3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-3.0.2.tgz#010d5858423a5f118979665f46486a95c6ee2bb6"
-  integrity sha1-AQ1YWEI6XxGJeWZfRkhqlcbuK7Y=
 
 es6-promisify@^5.0.0:
   version "5.0.0"
@@ -10966,18 +10961,7 @@ jsx-ast-utils@^2.2.1, jsx-ast-utils@^2.2.3:
     array-includes "^3.0.3"
     object.assign "^4.1.0"
 
-jszip@3.1.5:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/jszip/-/jszip-3.1.5.tgz#e3c2a6c6d706ac6e603314036d43cd40beefdf37"
-  integrity sha512-5W8NUaFRFRqTOL7ZDDrx5qWHJyBXy6velVudIzQUSoqAAYqzSh2Z7/m0Rf1QbmQJccegD0r+YZxBjzqoBiEeJQ==
-  dependencies:
-    core-js "~2.3.0"
-    es6-promise "~3.0.2"
-    lie "~3.1.0"
-    pako "~1.0.2"
-    readable-stream "~2.0.6"
-
-jszip@3.4.0, jszip@^3.2.2:
+jszip@3.1.5, jszip@3.4.0, jszip@^3.2.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/jszip/-/jszip-3.4.0.tgz#1a69421fa5f0bb9bc222a46bca88182fba075350"
   integrity sha512-gZAOYuPl4EhPTXT0GjhI3o+ZAz3su6EhLrKUoAivcKqyqC7laS5JEv4XWZND9BgcDcF83vI85yGbDmDR6UhrIg==
@@ -11144,13 +11128,6 @@ levn@^0.4.1:
   dependencies:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
-
-lie@~3.1.0:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/lie/-/lie-3.1.1.tgz#9a436b2cc7746ca59de7a41fa469b3efb76bd87e"
-  integrity sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=
-  dependencies:
-    immediate "~3.0.5"
 
 lie@~3.3.0:
   version "3.3.0"
@@ -14136,11 +14113,6 @@ process-nextick-args@^2.0.0, process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
-process-nextick-args@~1.0.6:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
-  integrity sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=
-
 process@^0.11.10:
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
@@ -14949,18 +14921,6 @@ readable-stream@^3.0.6, readable-stream@^3.1.1, readable-stream@^3.4.0, readable
     inherits "^2.0.3"
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
-
-readable-stream@~2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.0.6.tgz#8f90341e68a53ccc928788dacfcd11b36eb9b78e"
-  integrity sha1-j5A0HmilPMySh4jaz80Rs265t44=
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "~1.0.0"
-    process-nextick-args "~1.0.6"
-    string_decoder "~0.10.x"
-    util-deprecate "~1.0.1"
 
 readdirp@^2.2.1:
   version "2.2.1"


### PR DESCRIPTION
## Related issues and PRs
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->

`snyk protect` command was crashig with:

```
$ yarn snyk-protect
yarn run v1.22.4
$ snyk protect
Error: Cannot find module 'core-js/library/fn/set-immediate'
Require stack:
- node_modules/snyk-nuget-plugin/node_modules/jszip/lib/utils.js
- node_modules/snyk-nuget-plugin/node_modules/jszip/lib/utf8.js
- node_modules/snyk-nuget-plugin/node_modules/jszip/lib/object.js
- node_modules/snyk-nuget-plugin/node_modules/jszip/lib/index.js
- node_modules/snyk-nuget-plugin/dist/nuget-parser/nuspec-parser.js
- node_modules/snyk-nuget-plugin/dist/nuget-parser/dotnet-framework-parser.js
- node_modules/snyk-nuget-plugin/dist/nuget-parser/index.js
- node_modules/snyk-nuget-plugin/dist/index.js
- node_modules/snyk/dist/lib/plugins/index.js
- node_modules/snyk/dist/lib/plugins/get-single-plugin-result.js
- node_modules/snyk/dist/lib/plugins/get-multi-plugin-result.js
- node_modules/snyk/dist/lib/plugins/get-deps-from-plugin.js
- node_modules/snyk/dist/lib/snyk-test/run-test.js
- node_modules/snyk/dist/lib/snyk-test/index.js
- node_modules/snyk/dist/lib/index.js
- node_modules/snyk/dist/lib/analytics.js
- node_modules/snyk/dist/cli/index.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:1020:15)
    at Function.Module._load (internal/modules/cjs/loader.js:890:27)
    at Module.require (internal/modules/cjs/loader.js:1080:19)
    at require (internal/modules/cjs/helpers.js:72:18)
    at Object.<anonymous> (node_modules/snyk-nuget-plugin/node_modules/jszip/lib/utils.js:6:20)
    at Module._compile (internal/modules/cjs/loader.js:1176:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1196:10)
    at Module.load (internal/modules/cjs/loader.js:1040:32)
    at Function.Module._load (internal/modules/cjs/loader.js:929:14)
    at Module.require (internal/modules/cjs/loader.js:1080:19)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

```

## Description
<!-- Goal of the pull request -->

The crash was due to mismatch in `core-js` version: `snyk` relies on  `core-js@2` via `jszip` and `snyk-nuget-plugin` (why do we even have the C# plugin here?), while we forcefully resolve `core-js` to version 3 using yarn resolutions. 

Happily the dependency on `core-js` was dropped in `jszip@3.4.0`, so we resolve `jszip` to `3.4.0` now. This fixes the crash.

## Impacted Areas in the application
<!-- Components of the application that this PR will change -->


## Testing
<!-- Steps to test the changes proposed by this PR -->
