### PR TITLE
Refactor computeNewEmpiricalCases into module with unit tests.

### DIFF
--- a/src/components/Main/Results/DeterministicLinePlot.tsx
+++ b/src/components/Main/Results/DeterministicLinePlot.tsx
@@ -32,7 +32,7 @@ import { LinePlotTooltip } from './LinePlotTooltip'
 import { MitigationPlot } from './MitigationLinePlot'
 import { R0Plot } from './R0LinePlot'
 
-import { verifyPositive, verifyTuple } from './Utils'
+import { verifyPositive, verifyTuple, computeNewEmpiricalCases } from './Utils'
 
 import './DeterministicLinePlot.scss'
 
@@ -53,46 +53,6 @@ function legendFormatter(enabledPlots: string[], value?: LegendPayload['value'],
   }
 
   return <span className={activeClassName}>{value}</span>
-}
-
-type maybeNumber = number | undefined
-
-function computeNewEmpiricalCases(
-  timeWindow: number,
-  verifyPositive: (x: number) => number | undefined,
-  cumulativeCounts?: CaseCountsDatum[],
-): [maybeNumber[], number] {
-  const newEmpiricalCases: maybeNumber[] = []
-  const deltaDay = Math.floor(timeWindow)
-  const deltaInt = timeWindow - deltaDay
-
-  if (!cumulativeCounts) {
-    return [newEmpiricalCases, deltaDay]
-  }
-
-  cumulativeCounts.forEach((_0, day) => {
-    if (day < deltaDay) {
-      newEmpiricalCases[day] = undefined
-      return
-    }
-
-    const startDay = day - deltaDay
-    const startDayPlus = day - deltaDay - 1
-
-    const nowCases = cumulativeCounts[day].cases
-    const oldCases = cumulativeCounts[startDay].cases
-    const olderCases = cumulativeCounts[startDayPlus]?.cases
-    if (oldCases && nowCases) {
-      const newCases = verifyPositive(
-        olderCases ? (1 - deltaInt) * (nowCases - oldCases) + deltaInt * (nowCases - olderCases) : nowCases - oldCases,
-      )
-      newEmpiricalCases.push(newCases)
-      return
-    }
-    newEmpiricalCases[day] = undefined
-  })
-
-  return [newEmpiricalCases, deltaDay]
 }
 
 export interface LinePlotProps {
@@ -137,7 +97,6 @@ export function DeterministicLinePlot({
 
   const [newEmpiricalCases, caseTimeWindow] = computeNewEmpiricalCases(
     params.epidemiological.infectiousPeriodDays,
-    verifyPositive,
     caseCounts,
   )
 

--- a/src/components/Main/Results/Utils.test.ts
+++ b/src/components/Main/Results/Utils.test.ts
@@ -1,4 +1,4 @@
-import { verifyPositive, verifyTuple } from './Utils'
+import { verifyPositive, verifyTuple, computeNewEmpiricalCases } from './Utils'
 
 describe('verifyPositive', () => {
   it('integer greater than zero returns same integer', () => {
@@ -33,5 +33,42 @@ describe('verifyTuple', () => {
 
   it('input [a, b] returns [a,b]', () => {
     expect(verifyTuple([1, 2])).toStrictEqual([1, 2])
+  })
+})
+
+describe('computeNewEmpiricalCases', () => {
+  /* Note that this test presumes the 'time' field is not used by the computeNewEmpiricalCases */
+  /* The assumption is correct at the time of writing, and exploited to make the test simpler. */
+  /* But the time field must be present to keep the typescript compiler happy. */
+  const time = new Date(0)
+  const cumulativeCounts = [
+    { cases: 1, time },
+    { cases: 2, time },
+    { cases: 4, time },
+    { cases: 6, time },
+    { cases: 6, time },
+    { cases: 7, time },
+  ]
+  it('returns empty result if cumulativeCounts parameter is undefined.', () => {
+    const got = computeNewEmpiricalCases(3)
+    expect(got).toStrictEqual([[], 3])
+  })
+
+  it('computes with a timeWindow of 1', () => {
+    const [newEmpiricalCases, deltaDay] = computeNewEmpiricalCases(1, cumulativeCounts)
+    expect(newEmpiricalCases).toEqual([undefined, 1, 2, 2, undefined, 1])
+    expect(deltaDay).toEqual(1)
+  })
+
+  it('computes with a timeWindow that evenly divides cumulativeCounts', () => {
+    const [newEmpiricalCases, deltaDay] = computeNewEmpiricalCases(2, cumulativeCounts)
+    expect(newEmpiricalCases).toEqual([undefined, undefined, 3, 4, 2, 1])
+    expect(deltaDay).toEqual(2)
+  })
+
+  it('computes with a timeWindow that does not evenly divide cumulativeCounts', () => {
+    const [newEmpiricalCases, deltaDay] = computeNewEmpiricalCases(4, cumulativeCounts)
+    expect(newEmpiricalCases).toEqual([undefined, undefined, undefined, undefined, 5, 5])
+    expect(deltaDay).toEqual(4)
   })
 })

--- a/src/components/Main/Results/Utils.ts
+++ b/src/components/Main/Results/Utils.ts
@@ -26,7 +26,6 @@ export function computeNewEmpiricalCases(
   const deltaInt = timeWindow - deltaDay
 
   if (!cumulativeCounts) {
-    console.log(timeWindow, cumulativeCounts, newEmpiricalCases, deltaDay)
     return [newEmpiricalCases, deltaDay]
   }
 
@@ -52,6 +51,5 @@ export function computeNewEmpiricalCases(
     newEmpiricalCases[day] = undefined
   })
 
-  console.log(timeWindow, cumulativeCounts, newEmpiricalCases, deltaDay)
   return [newEmpiricalCases, deltaDay]
 }

--- a/src/components/Main/Results/Utils.ts
+++ b/src/components/Main/Results/Utils.ts
@@ -1,3 +1,5 @@
+import type { CaseCountsDatum } from '../../../algorithms/types/Param.types'
+
 export type maybeNumber = number | undefined
 
 export function verifyPositive(x: number): maybeNumber {
@@ -13,4 +15,43 @@ export function verifyTuple(x: [maybeNumber, maybeNumber]): [number, number] | u
   }
 
   return undefined
+}
+
+export function computeNewEmpiricalCases(
+  timeWindow: number,
+  cumulativeCounts?: CaseCountsDatum[],
+): [maybeNumber[], number] {
+  const newEmpiricalCases: maybeNumber[] = []
+  const deltaDay = Math.floor(timeWindow)
+  const deltaInt = timeWindow - deltaDay
+
+  if (!cumulativeCounts) {
+    console.log(timeWindow, cumulativeCounts, newEmpiricalCases, deltaDay)
+    return [newEmpiricalCases, deltaDay]
+  }
+
+  cumulativeCounts.forEach((_0, day) => {
+    if (day < deltaDay) {
+      newEmpiricalCases[day] = undefined
+      return
+    }
+
+    const startDay = day - deltaDay
+    const startDayPlus = day - deltaDay - 1
+
+    const nowCases = cumulativeCounts[day].cases
+    const oldCases = cumulativeCounts[startDay].cases
+    const olderCases = cumulativeCounts[startDayPlus]?.cases
+    if (oldCases && nowCases) {
+      const newCases = verifyPositive(
+        olderCases ? (1 - deltaInt) * (nowCases - oldCases) + deltaInt * (nowCases - olderCases) : nowCases - oldCases,
+      )
+      newEmpiricalCases.push(newCases)
+      return
+    }
+    newEmpiricalCases[day] = undefined
+  })
+
+  console.log(timeWindow, cumulativeCounts, newEmpiricalCases, deltaDay)
+  return [newEmpiricalCases, deltaDay]
 }


### PR DESCRIPTION
## Related issues and PRs

Related to [this Fixme](https://github.com/neherlab/covid19_scenarios/blob/1a382d629a300b549f6b5559378921b0f80bc191/src/components/Main/Results/DeterministicLinePlot.tsx#L107), an incremental refactoring of the DeterministicLinePlot component.

(Additional context: #636, #671)

## Description
Reduce the code complexity of `DeterministicLinePlot.tsx` by extracting the `computeNewEmpiricalCases()` methods into a utility module. Also adds units tests for the method to aid future refactoring.

## Impacted Areas in the application

Slight reorganization of the code. Adds more unit tests.

## Testing

Adds units tests for `computenewEmpiricalCases` in the `Utils.ts` module.

Run `yarn test` to test.