### PR TITLE
Refactor string translation in DeterministicLinePlot.tsx

### DIFF
--- a/src/components/Main/Results/ChartCommon.ts
+++ b/src/components/Main/Results/ChartCommon.ts
@@ -60,43 +60,43 @@ export const areasToPlot: LineProps[] = [
   {
     key: `${DATA_POINTS.Susceptible}Area`,
     color: colors.susceptible,
-    name: 'Susceptible uncertainty',
+    name: t('Susceptible uncertainty'),
     legendType: 'none',
   },
   {
     key: `${DATA_POINTS.Infectious}Area`,
     color: colors.infectious,
-    name: 'Infectious uncertainty',
+    name: t('Infectious uncertainty'),
     legendType: 'none',
   },
   {
     key: `${DATA_POINTS.Severe}Area`,
     color: colors.severe,
-    name: 'Severely ill uncertainty',
+    name: t('Severely ill uncertainty'),
     legendType: 'none',
   },
   {
     key: `${DATA_POINTS.Critical}Area`,
     color: colors.critical,
-    name: 'Patients in ICU (model) uncertainty',
+    name: t('Patients in ICU (model) uncertainty'),
     legendType: 'none',
   },
   {
     key: `${DATA_POINTS.Overflow}Area`,
     color: colors.overflow,
-    name: 'ICU overflow uncertainty',
+    name: t('ICU overflow uncertainty'),
     legendType: 'none',
   },
   {
     key: `${DATA_POINTS.Recovered}Area`,
     color: colors.recovered,
-    name: 'Recovered uncertainty',
+    name: t('Recovered uncertainty'),
     legendType: 'none',
   },
   {
     key: `${DATA_POINTS.Fatalities}Area`,
     color: colors.fatality,
-    name: 'Cumulative deaths (model) uncertainty',
+    name: t('Cumulative deaths (model) uncertainty'),
     legendType: 'none',
   },
 ]
@@ -109,10 +109,4 @@ export function observationsToPlot(casesDelta: number): LineProps[] {
     { key: DATA_POINTS.ObservedICU, color: colors.critical, name: t('Patients in ICU (data)') },
     { key: DATA_POINTS.ObservedDeaths, color: colors.fatality, name: t('Cumulative deaths (data)') },
   ]
-}
-
-export function translatePlots(t: TFunction, lines: LineProps[]): LineProps[] {
-  return lines.map((line) => {
-    return { ...line, name: t(line.name) }
-  })
 }

--- a/src/components/Main/Results/ChartCommon.ts
+++ b/src/components/Main/Results/ChartCommon.ts
@@ -45,15 +45,15 @@ export const colors = {
 }
 
 export const linesToPlot: LineProps[] = [
-  { key: DATA_POINTS.Susceptible, color: colors.susceptible, name: 'Susceptible', legendType: 'line' },
-  { key: DATA_POINTS.Recovered, color: colors.recovered, name: 'Recovered', legendType: 'line' },
-  { key: DATA_POINTS.Infectious, color: colors.infectious, name: 'Infectious', legendType: 'line' },
-  { key: DATA_POINTS.Severe, color: colors.severe, name: 'Severely ill', legendType: 'line' },
-  { key: DATA_POINTS.Critical, color: colors.critical, name: 'Patients in ICU (model)', legendType: 'line' },
-  { key: DATA_POINTS.Overflow, color: colors.overflow, name: 'ICU overflow', legendType: 'line' },
-  { key: DATA_POINTS.Fatalities, color: colors.fatality, name: 'Cumulative deaths (model)', legendType: 'line' },
-  { key: DATA_POINTS.HospitalBeds, color: colors.hospitalBeds, name: 'Total hospital beds', legendType: 'none' },
-  { key: DATA_POINTS.ICUbeds, color: colors.ICUbeds, name: 'Total ICU/ICM beds', legendType: 'none' },
+  { key: DATA_POINTS.Susceptible, color: colors.susceptible, name: t('Susceptible'), legendType: 'line' },
+  { key: DATA_POINTS.Recovered, color: colors.recovered, name: t('Recovered'), legendType: 'line' },
+  { key: DATA_POINTS.Infectious, color: colors.infectious, name: t('Infectious'), legendType: 'line' },
+  { key: DATA_POINTS.Severe, color: colors.severe, name: t('Severely ill'), legendType: 'line' },
+  { key: DATA_POINTS.Critical, color: colors.critical, name: t('Patients in ICU (model)'), legendType: 'line' },
+  { key: DATA_POINTS.Overflow, color: colors.overflow, name: t('ICU overflow'), legendType: 'line' },
+  { key: DATA_POINTS.Fatalities, color: colors.fatality, name: t('Cumulative deaths (model)'), legendType: 'line' },
+  { key: DATA_POINTS.HospitalBeds, color: colors.hospitalBeds, name: t('Total hospital beds'), legendType: 'none' },
+  { key: DATA_POINTS.ICUbeds, color: colors.ICUbeds, name: t('Total ICU/ICM beds'), legendType: 'none' },
 ]
 
 export const areasToPlot: LineProps[] = [
@@ -103,11 +103,11 @@ export const areasToPlot: LineProps[] = [
 
 export function observationsToPlot(casesDelta: number): LineProps[] {
   return [
-    { key: DATA_POINTS.ObservedCases, color: colors.cumulativeCases, name: 'Cumulative cases (data)' },
-    { key: DATA_POINTS.ObservedNewCases, color: colors.newCases, name: `Cases past ${casesDelta} day(s) (data)` },
-    { key: DATA_POINTS.ObservedHospitalized, color: colors.severe, name: 'Patients in hospital (data)' },
-    { key: DATA_POINTS.ObservedICU, color: colors.critical, name: 'Patients in ICU (data)' },
-    { key: DATA_POINTS.ObservedDeaths, color: colors.fatality, name: 'Cumulative deaths (data)' },
+    { key: DATA_POINTS.ObservedCases, color: colors.cumulativeCases, name: t('Cumulative cases (data)') },
+    { key: DATA_POINTS.ObservedNewCases, color: colors.newCases, name: t(`Cases past ${casesDelta} day(s) (data)`) },
+    { key: DATA_POINTS.ObservedHospitalized, color: colors.severe, name: t('Patients in hospital (data)') },
+    { key: DATA_POINTS.ObservedICU, color: colors.critical, name: t('Patients in ICU (data)') },
+    { key: DATA_POINTS.ObservedDeaths, color: colors.fatality, name: t('Cumulative deaths (data)') },
   ]
 }
 

--- a/src/components/Main/Results/DeterministicLinePlot.tsx
+++ b/src/components/Main/Results/DeterministicLinePlot.tsx
@@ -220,7 +220,7 @@ export function DeterministicLinePlot({
   const tMin = _.minBy(plotData, 'time')!.time // eslint-disable-line @typescript-eslint/no-non-null-assertion
   const tMax = _.maxBy(plotData, 'time')!.time // eslint-disable-line @typescript-eslint/no-non-null-assertion
 
-  const reducedObservationsToPlot = translatePlots(t, observationsToPlot(caseTimeWindow)).filter((itemToPlot) => {
+  const reducedObservationsToPlot = observationsToPlot(caseTimeWindow).filter((itemToPlot) => {
     if (observations.length !== 0) {
       if (countObservations.cases && itemToPlot.key === DATA_POINTS.ObservedCases) {
         return true

--- a/src/components/Main/Results/DeterministicLinePlot.tsx
+++ b/src/components/Main/Results/DeterministicLinePlot.tsx
@@ -362,7 +362,7 @@ export function DeterministicLinePlot({
                   />
                 ))}
 
-                {translatePlots(t, areasToPlot).map((d) => (
+                {areasToPlot.map((d) => (
                   <Area
                     key={d.key}
                     type="monotone"

--- a/src/components/Main/Results/DeterministicLinePlot.tsx
+++ b/src/components/Main/Results/DeterministicLinePlot.tsx
@@ -27,7 +27,7 @@ import type { AlgorithmResult } from '../../../algorithms/types/Result.types'
 
 import { numberFormatter } from '../../../helpers/numberFormat'
 import { calculatePosition, scrollToRef } from './chartHelper'
-import { linesToPlot, areasToPlot, observationsToPlot, DATA_POINTS, translatePlots } from './ChartCommon'
+import { linesToPlot, areasToPlot, observationsToPlot, DATA_POINTS } from './ChartCommon'
 import { LinePlotTooltip } from './LinePlotTooltip'
 import { MitigationPlot } from './MitigationLinePlot'
 import { R0Plot } from './R0LinePlot'

--- a/src/components/Main/Results/DeterministicLinePlot.tsx
+++ b/src/components/Main/Results/DeterministicLinePlot.tsx
@@ -348,7 +348,7 @@ export function DeterministicLinePlot({
                   <Scatter key={d.key} dataKey={d.key} fill={d.color} name={d.name} isAnimationActive={false} />
                 ))}
 
-                {translatePlots(t, linesToPlot).map((d) => (
+                {linesToPlot.map((d) => (
                   <Line
                     key={d.key}
                     dot={false}


### PR DESCRIPTION
## Related issues and PRs

Related to [this Fixme](https://github.com/neherlab/covid19_scenarios/blob/1a382d629a300b549f6b5559378921b0f80bc191/src/components/Main/Results/DeterministicLinePlot.tsx#L107), an incremental refactoring of the DeterministicLinePlot component.

(Additional context: #636, #671, #677 )

## Description
<!-- Goal of the pull request -->

## Impacted Areas in the application

Reduce the code complexity of `DeterministicLinePlot.tsx` by removing the unnecessary 'translatePlots()' function and doing all necessary translation when strings are first defined. 