### PR TITLE
Refactor DeterministiclinePlot's caseCount -> observationsToPlot filter.

### DIFF
--- a/src/components/Main/Results/DeterministicLinePlot.tsx
+++ b/src/components/Main/Results/DeterministicLinePlot.tsx
@@ -227,8 +227,6 @@ export function DeterministicLinePlot({
     return false
   })
 
-  const translatedPlots = translatePlots(t, observationsHavingDataToPlot)
-
   let tooltipItems: { [key: string]: number | undefined } = {}
   consolidatedPlotData.forEach((d) => {
     // @ts-ignore
@@ -332,7 +330,7 @@ export function DeterministicLinePlot({
                   }}
                 />
 
-                {translatedPlots.map((d) => (
+                {translatePlots(t, observationsHavingDataToPlot).map((d) => (
                   <Scatter key={d.key} dataKey={d.key} fill={d.color} name={d.name} isAnimationActive={false} />
                 ))}
 

--- a/src/components/Main/Results/DeterministicLinePlot.tsx
+++ b/src/components/Main/Results/DeterministicLinePlot.tsx
@@ -220,7 +220,7 @@ export function DeterministicLinePlot({
   const tMin = _.minBy(plotData, 'time')!.time // eslint-disable-line @typescript-eslint/no-non-null-assertion
   const tMax = _.maxBy(plotData, 'time')!.time // eslint-disable-line @typescript-eslint/no-non-null-assertion
 
-  const reducedObservationsToPlot = translatePlots(t, observationsToPlot(caseTimeWindow)).filter((itemToPlot) => {
+  const reducedObservationsToPlot = observationsToPlot(caseTimeWindow).filter((itemToPlot) => {
     if (observations.length !== 0) {
       if (countObservations.cases && itemToPlot.key === DATA_POINTS.ObservedCases) {
         return true
@@ -240,6 +240,8 @@ export function DeterministicLinePlot({
     }
     return false
   })
+
+  const translatedPlots = translatePlots(t, reducedObservationsToPlot)
 
   let tooltipItems: { [key: string]: number | undefined } = {}
   consolidatedPlotData.forEach((d) => {
@@ -344,7 +346,7 @@ export function DeterministicLinePlot({
                   }}
                 />
 
-                {reducedObservationsToPlot.map((d) => (
+                {translatedPlots.map((d) => (
                   <Scatter key={d.key} dataKey={d.key} fill={d.color} name={d.name} isAnimationActive={false} />
                 ))}
 

--- a/src/components/Main/Results/DeterministicLinePlot.tsx
+++ b/src/components/Main/Results/DeterministicLinePlot.tsx
@@ -221,7 +221,7 @@ export function DeterministicLinePlot({
   const tMax = _.maxBy(plotData, 'time')!.time // eslint-disable-line @typescript-eslint/no-non-null-assertion
 
   const observationsHavingDataToPlot = observationsToPlot(caseTimeWindow).filter((itemToPlot) => {
-    if (observations.length) {
+    if (observations.length !== 0) {
       return hasObservations[itemToPlot.key]
     }
     return false

--- a/src/components/Main/Results/DeterministicLinePlot.tsx
+++ b/src/components/Main/Results/DeterministicLinePlot.tsx
@@ -213,11 +213,11 @@ export function DeterministicLinePlot({
   const tMax = _.maxBy(plotData, 'time')!.time // eslint-disable-line @typescript-eslint/no-non-null-assertion
 
   const countObservations = {
-    cases: caseCounts?.filter((d) => d.cases).length ?? 0,
-    ICU: caseCounts?.filter((d) => d.icu).length ?? 0,
-    observedDeaths: caseCounts?.filter((d) => d.deaths).length ?? 0,
-    newCases: caseCounts?.filter((_0, i) => newEmpiricalCases[i]).length ?? 0,
-    hospitalized: caseCounts?.filter((d) => d.hospitalized).length ?? 0,
+    cases: caseCounts && caseCounts.some((d) => d.cases),
+    ICU: caseCounts && caseCounts.some((d) => d.icu),
+    observedDeaths: caseCounts && caseCounts.some((d) => d.deaths),
+    newCases: newEmpiricalCases && newEmpiricalCases.some((d) => d),
+    hospitalized: caseCounts && caseCounts.somw((d) => d.hospitalized),
   }
 
   const reducedObservationsToPlot = observationsToPlot(caseTimeWindow).filter((itemToPlot) => {

--- a/src/components/Main/Results/DeterministicLinePlot.tsx
+++ b/src/components/Main/Results/DeterministicLinePlot.tsx
@@ -100,14 +100,6 @@ export function DeterministicLinePlot({
     caseCounts,
   )
 
-  const countObservations = {
-    cases: caseCounts?.filter((d) => d.cases).length ?? 0,
-    ICU: caseCounts?.filter((d) => d.icu).length ?? 0,
-    observedDeaths: caseCounts?.filter((d) => d.deaths).length ?? 0,
-    newCases: caseCounts?.filter((_0, i) => newEmpiricalCases[i]).length ?? 0,
-    hospitalized: caseCounts?.filter((d) => d.hospitalized).length ?? 0,
-  }
-
   const observations =
     caseCounts?.map((d, i) => ({
       time: new Date(d.time).getTime(),
@@ -219,6 +211,14 @@ export function DeterministicLinePlot({
 
   const tMin = _.minBy(plotData, 'time')!.time // eslint-disable-line @typescript-eslint/no-non-null-assertion
   const tMax = _.maxBy(plotData, 'time')!.time // eslint-disable-line @typescript-eslint/no-non-null-assertion
+
+  const countObservations = {
+    cases: caseCounts?.filter((d) => d.cases).length ?? 0,
+    ICU: caseCounts?.filter((d) => d.icu).length ?? 0,
+    observedDeaths: caseCounts?.filter((d) => d.deaths).length ?? 0,
+    newCases: caseCounts?.filter((_0, i) => newEmpiricalCases[i]).length ?? 0,
+    hospitalized: caseCounts?.filter((d) => d.hospitalized).length ?? 0,
+  }
 
   const reducedObservationsToPlot = observationsToPlot(caseTimeWindow).filter((itemToPlot) => {
     if (observations.length !== 0) {

--- a/src/components/Main/Results/DeterministicLinePlot.tsx
+++ b/src/components/Main/Results/DeterministicLinePlot.tsx
@@ -220,7 +220,7 @@ export function DeterministicLinePlot({
     hospitalized: caseCounts && caseCounts.some((d) => d.hospitalized),
   }
 
-  const reducedObservationsToPlot = observationsToPlot(caseTimeWindow).filter((itemToPlot) => {
+  const observationsWithDataToPlot = observationsToPlot(caseTimeWindow).filter((itemToPlot) => {
     if (observations.length !== 0) {
       if (hasObservations.cases && itemToPlot.key === DATA_POINTS.ObservedCases) {
         return true
@@ -241,7 +241,7 @@ export function DeterministicLinePlot({
     return false
   })
 
-  const translatedPlots = translatePlots(t, reducedObservationsToPlot)
+  const translatedPlots = translatePlots(t, observationsWithDataToPlot)
 
   let tooltipItems: { [key: string]: number | undefined } = {}
   consolidatedPlotData.forEach((d) => {

--- a/src/components/Main/Results/DeterministicLinePlot.tsx
+++ b/src/components/Main/Results/DeterministicLinePlot.tsx
@@ -100,6 +100,14 @@ export function DeterministicLinePlot({
     caseCounts,
   )
 
+  const hasObservations = {
+    [DATA_POINTS.ObservedCases]: caseCounts && caseCounts.some((d) => d.cases),
+    [DATA_POINTS.ObservedICU]: caseCounts && caseCounts.some((d) => d.icu),
+    [DATA_POINTS.ObservedDeaths]: caseCounts && caseCounts.some((d) => d.deaths),
+    [DATA_POINTS.ObservedNewCases]: newEmpiricalCases && newEmpiricalCases.some((d) => d),
+    [DATA_POINTS.ObservedHospitalized]: caseCounts && caseCounts.some((d) => d.hospitalized),
+  }
+
   const observations =
     caseCounts?.map((d, i) => ({
       time: new Date(d.time).getTime(),
@@ -212,36 +220,14 @@ export function DeterministicLinePlot({
   const tMin = _.minBy(plotData, 'time')!.time // eslint-disable-line @typescript-eslint/no-non-null-assertion
   const tMax = _.maxBy(plotData, 'time')!.time // eslint-disable-line @typescript-eslint/no-non-null-assertion
 
-  const hasObservations = {
-    cases: caseCounts && caseCounts.some((d) => d.cases),
-    ICU: caseCounts && caseCounts.some((d) => d.icu),
-    observedDeaths: caseCounts && caseCounts.some((d) => d.deaths),
-    newCases: newEmpiricalCases && newEmpiricalCases.some((d) => d),
-    hospitalized: caseCounts && caseCounts.some((d) => d.hospitalized),
-  }
-
-  const observationsWithDataToPlot = observationsToPlot(caseTimeWindow).filter((itemToPlot) => {
-    if (observations.length !== 0) {
-      if (hasObservations.cases && itemToPlot.key === DATA_POINTS.ObservedCases) {
-        return true
-      }
-      if (hasObservations.newCases && itemToPlot.key === DATA_POINTS.ObservedNewCases) {
-        return true
-      }
-      if (hasObservations.hospitalized && itemToPlot.key === DATA_POINTS.ObservedHospitalized) {
-        return true
-      }
-      if (hasObservations.ICU && itemToPlot.key === DATA_POINTS.ObservedICU) {
-        return true
-      }
-      if (hasObservations.observedDeaths && itemToPlot.key === DATA_POINTS.ObservedDeaths) {
-        return true
-      }
+  const observationsHavingDataToPlot = observationsToPlot(caseTimeWindow).filter((itemToPlot) => {
+    if (observations.length) {
+      return hasObservations[itemToPlot.key]
     }
     return false
   })
 
-  const translatedPlots = translatePlots(t, observationsWithDataToPlot)
+  const translatedPlots = translatePlots(t, observationsHavingDataToPlot)
 
   let tooltipItems: { [key: string]: number | undefined } = {}
   consolidatedPlotData.forEach((d) => {

--- a/src/components/Main/Results/DeterministicLinePlot.tsx
+++ b/src/components/Main/Results/DeterministicLinePlot.tsx
@@ -212,29 +212,29 @@ export function DeterministicLinePlot({
   const tMin = _.minBy(plotData, 'time')!.time // eslint-disable-line @typescript-eslint/no-non-null-assertion
   const tMax = _.maxBy(plotData, 'time')!.time // eslint-disable-line @typescript-eslint/no-non-null-assertion
 
-  const countObservations = {
+  const hasObservations = {
     cases: caseCounts && caseCounts.some((d) => d.cases),
     ICU: caseCounts && caseCounts.some((d) => d.icu),
     observedDeaths: caseCounts && caseCounts.some((d) => d.deaths),
     newCases: newEmpiricalCases && newEmpiricalCases.some((d) => d),
-    hospitalized: caseCounts && caseCounts.somw((d) => d.hospitalized),
+    hospitalized: caseCounts && caseCounts.some((d) => d.hospitalized),
   }
 
   const reducedObservationsToPlot = observationsToPlot(caseTimeWindow).filter((itemToPlot) => {
     if (observations.length !== 0) {
-      if (countObservations.cases && itemToPlot.key === DATA_POINTS.ObservedCases) {
+      if (hasObservations.cases && itemToPlot.key === DATA_POINTS.ObservedCases) {
         return true
       }
-      if (countObservations.newCases && itemToPlot.key === DATA_POINTS.ObservedNewCases) {
+      if (hasObservations.newCases && itemToPlot.key === DATA_POINTS.ObservedNewCases) {
         return true
       }
-      if (countObservations.hospitalized && itemToPlot.key === DATA_POINTS.ObservedHospitalized) {
+      if (hasObservations.hospitalized && itemToPlot.key === DATA_POINTS.ObservedHospitalized) {
         return true
       }
-      if (countObservations.ICU && itemToPlot.key === DATA_POINTS.ObservedICU) {
+      if (hasObservations.ICU && itemToPlot.key === DATA_POINTS.ObservedICU) {
         return true
       }
-      if (countObservations.observedDeaths && itemToPlot.key === DATA_POINTS.ObservedDeaths) {
+      if (hasObservations.observedDeaths && itemToPlot.key === DATA_POINTS.ObservedDeaths) {
         return true
       }
     }


### PR DESCRIPTION
## Related issues and PRs

Related to [this Fixme](https://github.com/neherlab/covid19_scenarios/blob/1a382d629a300b549f6b5559378921b0f80bc191/src/components/Main/Results/DeterministicLinePlot.tsx#L107), an incremental refactoring of the DeterministicLinePlot component.

(Additional context: #636, #671, #677)

## Description

Reduce the code complexity of `DeterministicLinePlot.tsx` by using computed property names to associate caseCounts with plotted data. This refactoring reduces the number of conditional statements and improves communication of intention.

## Impacted Areas in the application

Functionality unchanged, but the code `DeterministicLinePlot.tsx` is slightly changed. 


## Testing

No unit tests were added by this change.
