### PR TITLE
Add a simple CLI for use in unified model interface

### DIFF
--- a/src/algorithms/cli.ts
+++ b/src/algorithms/cli.ts
@@ -1,0 +1,77 @@
+import * as fs from 'fs'
+import { run } from './run'
+import { ScenarioFlat, ScenarioData } from './types/Param.types'
+import { getAgeDistribution } from '../components/Main/state/getAgeDistribution'
+import { getSeverityDistribution } from '../components/Main/state/getSeverityDistribution'
+import { toInternal } from '../components/Main/state/getScenario'
+
+const handleRejection: NodeJS.UnhandledRejectionListener = (err) => {
+  console.error(err)
+  process.exit(1)
+}
+
+process.on('unhandledRejection', handleRejection)
+
+function readJsonFromFile<T>(arg: number) {
+  const inputFilename = process.argv[arg]
+  if (!inputFilename) {
+    usage()
+  }
+  console.log(`Reading data from file ${inputFilename}`)
+  const inputData = fs.readFileSync(inputFilename, 'utf8')
+  const inputJson = JSON.parse(inputData) as T
+  console.log(`Read input data`)
+  return inputJson
+}
+
+async function main() {
+  const scenarioData = readJsonFromFile<ScenarioData>(2)
+  const outputFile = process.argv[3]
+  if (!outputFile) {
+    usage()
+  }
+  console.log(`Will write model output to ${outputFile}`)
+
+  const scenario = toInternal(scenarioData.data)
+
+  const params: ScenarioFlat = {
+    ...scenario.population,
+    ...scenario.epidemiological,
+    ...scenario.simulation,
+    ...scenario.mitigation,
+  }
+  // Read data from severityDistributions.json and perform JSON validation.
+  // Use the model's default (and only) severity distribution.
+  console.log(`Reading severity distribution data`)
+  const DEFAULT_SEVERITY_DISTRIBUTION = 'China CDC'
+  const severity = getSeverityDistribution(DEFAULT_SEVERITY_DISTRIBUTION)
+  // Read data from ageDistribution.json and perform JSON validation.
+  console.log(`Reading age distribution data`)
+  const ageDistribution = getAgeDistribution(params.ageDistributionName)
+
+  try {
+    console.log('Running the model')
+    const result = await run({ params, severity, ageDistribution })
+    console.log('Run complete')
+    console.log(result)
+    console.log(`Writing output to ${outputFile}`)
+    fs.writeFileSync(outputFile, JSON.stringify(result))
+  } catch (error) {
+    console.error(`Run failed: ${error}`)
+    process.exit(1)
+  }
+}
+
+function usage() {
+  console.log(
+    `
+Usage:
+    cli <input-file> <output-file>
+        Manually perform a single model run with the given input, writing the results to the given output file.
+    `.trim(),
+  )
+
+  process.exit(1)
+}
+
+main()

--- a/src/algorithms/cli.ts
+++ b/src/algorithms/cli.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console, unicorn/no-process-exit */
 import * as fs from 'fs'
 import { run } from './run'
 import { ScenarioFlat, ScenarioData } from './types/Param.types'


### PR DESCRIPTION
## Related issues and PRs
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->
 - Related to https://github.com/neherlab/covid19_scenarios/issues/663, though not yet a fully-featured CLI.

## Description
<!-- Goal of the pull request -->
This PR adds a simple CLI entry point that:
- reads input JSON (of type `ScenarioData`) from a specified input path
- runs the model by calling into `run.ts`
- writes output JSON (of type `AlgorithmResult`) into the specified output path

This allows the model to be run in a unified model UI, such as the one we are maintaining at https://github.com/covid-modeling on the GitHub side. We are already using a version of this at https://github.com/covid-modeling/model-runner to run this model, but are currently tied to my fork that has the CLI entry point and an older version of your model. Having this code as part of the model repo enables the unified interface to keep up with model changes, and so better represent the latest state of your model.

@ivan-aksamentov @nnoll I would be grateful for a review, and hope this will minimally impact your existing work. Let me know if you have questions.

## Impacted Areas in the application
<!-- Components of the application that this PR will change -->
No changes to existing code, introduces new entry point that calls `run`.

## Testing
<!-- Steps to test the changes proposed by this PR -->
1. Usual schema preparation: `yarn schema:clean && yarn schema:totypes`.
1. Write a JSON object of type `ScenarioData` in a file, say `input-file.json`. One of the existing objects in `scenarios.json` will work.
1.
    ```
    yarn babel-node --extensions ".ts" src/algorithms/cli.ts path/to/input-file.json path/to/output-file.json
    ```
1. This will create output data at `path/to/output-file.json`, which is assumed to not already exist.