### PR TITLE
Command line runs

### DIFF
--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -1,0 +1,64 @@
+# Running via the Command Line
+
+You can run the model via the command line. You need to have `yarn` installed. You can then
+make use of the `cli` target, for example:
+```
+yarn cli --scenario=scenario.json --out=output.json
+``` 
+Both an input scenario file and an output file location are required arguments.
+An example of a scenario file:
+```json
+{
+  "data": {
+    "epidemiological": {
+      "hospitalStayDays": 3,
+      "icuStayDays": 14,
+      "infectiousPeriodDays": 3,
+      "latencyDays": 3,
+      "overflowSeverity": 2,
+      "peakMonth": 0,
+      "r0": {
+        "begin": 4.08,
+        "end": 4.98
+      },
+      "seasonalForcing": 0
+    },
+    "mitigation": {
+      "mitigationIntervals": [
+        {
+          "color": "#cccccc",
+          "name": "Intervention 1",
+          "timeRange": {
+            "begin": "2020-03-24T00:00:00.000Z",
+            "end": "2020-09-01T00:00:00.000Z"
+          },
+          "transmissionReduction": {
+            "begin": 73.8,
+            "end": 84.2
+          }
+        }
+      ]
+    },
+    "population": {
+      "ageDistributionName": "United States of America",
+      "caseCountsName": "United States of America",
+      "hospitalBeds": 798288,
+      "icuBeds": 49499,
+      "importsPerDay": 0.1,
+      "initialNumberOfCases": 1,
+      "populationServed": 327167434
+    },
+    "simulation": {
+      "numberStochasticRuns": 15,
+      "simulationTimeRange": {
+        "begin": "2020-02-08T00:00:00.000Z",
+        "end": "2020-08-31T00:00:00.000Z"
+      }
+    }
+  },
+  "name": "United States of America"
+}
+```
+
+A usage message is available via `yarn cli --help`.
+

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "i18n": "babel-node --extensions \".ts\" node_modules/.bin/i18next -c config/i18next/i18next.config.js",
     "codeclimate": "UID=$(id -u) DOCKER_BUILDKIT=1 COMPOSE_DOCKER_CLI_BUILD=1 docker-compose -f docker/docker-compose.codeclimate.yml --compatibility up",
     "snyk-protect": "snyk protect",
-    "prepare": "yarn run snyk-protect"
+    "prepare": "yarn run snyk-protect",
+    "cli": "yarn babel-node --extensions \".ts\" src/algorithms/cli.ts",
   },
   "dependencies": {
     "@babel/runtime": "7.9.6",
@@ -370,7 +371,8 @@
     "webpack-hot-middleware": "2.25.0",
     "webpackbar": "4.0.0",
     "worker-plugin": "4.0.3",
-    "yaml-loader": "0.6.0"
+    "yaml-loader": "0.6.0",
+    "yargs": "15.3.1"
   },
   "resolutions": {
     "**/babel-polyfill": "link:3rdparty/__empty-module",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "codeclimate": "UID=$(id -u) DOCKER_BUILDKIT=1 COMPOSE_DOCKER_CLI_BUILD=1 docker-compose -f docker/docker-compose.codeclimate.yml --compatibility up",
     "snyk-protect": "snyk protect",
     "prepare": "yarn run snyk-protect",
-    "cli": "yarn babel-node --extensions \".ts\" src/algorithms/cli.ts",
+    "cli": "yarn babel-node --extensions \".ts\" src/algorithms/cli.ts"
   },
   "dependencies": {
     "@babel/runtime": "7.9.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19049,6 +19049,23 @@ yargs@13.2.4:
     y18n "^4.0.0"
     yargs-parser "^13.1.0"
 
+yargs@15.3.1, yargs@^15.0.1, yargs@^15.3.1:
+  version "15.3.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.3.1.tgz#9505b472763963e54afe60148ad27a330818e98b"
+  integrity sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==
+  dependencies:
+    cliui "^6.0.0"
+    decamelize "^1.2.0"
+    find-up "^4.1.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^4.2.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^18.1.1"
+
 yargs@^1.2.6:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-1.3.3.tgz#054de8b61f22eefdb7207059eaef9d6b83fb931a"
@@ -19087,23 +19104,6 @@ yargs@^13.3.2:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^13.1.2"
-
-yargs@^15.0.1, yargs@^15.3.1:
-  version "15.3.1"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.3.1.tgz#9505b472763963e54afe60148ad27a330818e98b"
-  integrity sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==
-  dependencies:
-    cliui "^6.0.0"
-    decamelize "^1.2.0"
-    find-up "^4.1.0"
-    get-caller-file "^2.0.1"
-    require-directory "^2.1.1"
-    require-main-filename "^2.0.0"
-    set-blocking "^2.0.0"
-    string-width "^4.2.0"
-    which-module "^2.0.0"
-    y18n "^4.0.0"
-    yargs-parser "^18.1.1"
 
 yargs@^3.19.0:
   version "3.32.0"


### PR DESCRIPTION
Add a yarn target for running the model via the command line.

## Description
These changes allow the model to be run via the command line via a `yarn cli` call. Two arguments are required: `--scenario` and `--out`.
 
## Impacted Areas in the application
The changes are all pretty trivial. Some command line parsing is done via `yargs` in `src/algorithms/cli.ts` (and so a dependency is introduced on the [yargs](http://yargs.js.org/) package in `package.json`).

## Testing
1. Copy the example scenario parameters shown on `docs/comand_line.md` into a file `scenario.json`.
1. At the command line, execute `yarn cli --help` to see the usage message.
1. At the command line, execute `yarn cli --scenario=scenario.json --out=output.json`.
1. Confirm that `output.json` was created by the run and has reasonable-looking output.

## Additional Notes
* We are using these mods as we do some grid searching across input parameters.
* I recognize this is our first pull request to your project. We hope we have adhered to the contribution guidelines, but of course let us know how we can modify the changes to better suit the project. And equally, zero worries if you just want to reject the pull request.
* Thank you for your hard work on this project and for making it public so that we can all benefit and contribute.