### PR TITLE
ensure mitigation intervals are correctly sampled in production

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "covid19_scenarios",
-  "version": "1.4.9",
+  "version": "1.5.0",
   "main": "index.js",
   "module": "src/index.tsx",
   "license": "MIT",

--- a/src/algorithms/mitigation.ts
+++ b/src/algorithms/mitigation.ts
@@ -34,6 +34,7 @@ function sampleMitigationRealizations(
   const noRanges = intervals.every(
     (interval) => interval.transmissionReduction.begin === interval.transmissionReduction.end,
   )
+
   if (noRanges) {
     return [
       intervals.map((interval) => ({
@@ -44,13 +45,15 @@ function sampleMitigationRealizations(
     ]
   }
 
-  return [...Array(numberStochasticRuns).keys()].map(() =>
-    intervals.map((interval) => ({
-      val: strength(sampleRandom(interval.transmissionReduction)),
-      tMin: interval.timeRange.begin.valueOf(),
-      tMax: interval.timeRange.end.valueOf(),
-    })),
-  )
+  return Array(numberStochasticRuns)
+    .fill(1)
+    .map(() =>
+      intervals.map((interval) => ({
+        val: strength(sampleRandom(interval.transmissionReduction)),
+        tMin: interval.timeRange.begin.valueOf(),
+        tMax: interval.timeRange.end.valueOf(),
+      })),
+    )
 }
 
 function timeSeriesOf(measures: MitigationMeasure[]): TimeSeries {

--- a/src/assets/text/updates.md
+++ b/src/assets/text/updates.md
@@ -14,6 +14,15 @@ two types of reasons
 We realize this can be confusing, but in this evolving situation, this is difficult to avoid. We try to summarize the
 most significant model changes below.
 
+### 2020-06-09: Bugfix in mitigationInterval sampling.
+Our simulations include parameter uncertainty by sampling parameters from user-specified ranges.
+For somewhat subtle reasons, this sampling procedure behaved differently in the production and the development
+environment which result in using only one realization of the mitigation parameters.
+This was patched in [commit](https://github.com/neherlab/covid19_scenarios/pull/729/commits/35ba172229c944fa0b88efbd1e112ecdcd71e97f).
+As a result, you should expect that the confidence intervals increased, while the jumpiness from one realization to another
+should be reduced.
+
+
 ### 2020-05-22: Changes to the parameter presets
 
 Our parameter presets for R0, the initial number of cases, and interventions are meant to facilitate adjusting a


### PR DESCRIPTION
## Related issues and PRs
production version uses only one sample from the mitigation intervals which seems related to oddities of `[...Array(numberStochasticRuns).keys()]` in the production environment. 

## Description
`Array(numberStochasticRuns).fill(1)` returns a mappable array that does the trick

## Testing
check whether uncertainty is properly handled for mitigations