### PR TITLE
fix: disable loose transformations and shipped proposals in babel

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -12,7 +12,6 @@ const development = process.env.NODE_ENV === 'development'
 const production = process.env.NODE_ENV === 'production'
 const analyze = process.env.ANALYZE === '1'
 const debuggableProd = process.env.DEBUGGABLE_PROD === '1'
-const loose = true
 
 module.exports = (api) => {
   const web = api.caller(isWebTarget)
@@ -30,8 +29,6 @@ module.exports = (api) => {
           corejs: web ? 'core-js@3' : false,
           targets: !web ? { node: 'current' } : undefined,
           modules: webpack ? false : 'commonjs',
-          loose,
-          shippedProposals: development,
           exclude: ['transform-typeof-symbol'],
         },
       ],
@@ -39,7 +36,7 @@ module.exports = (api) => {
     ],
     plugins: [
       development && web && 'react-refresh/babel',
-      ['@babel/plugin-proposal-numeric-separator', { loose }],
+      ['@babel/plugin-proposal-numeric-separator'],
       'babel-plugin-lodash',
       (development || debuggableProd) && web && !analyze && ['babel-plugin-typescript-to-proptypes', { typeCheck: './src/**/*.ts' }], // prettier-ignore
       (development || debuggableProd) && web && !analyze && 'babel-plugin-redux-saga', // prettier-ignore


### PR DESCRIPTION
## Related issues and PRs
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->

Related to the issue resolved in https://github.com/neherlab/covid19_scenarios/pull/729.

#729 solves the problem for this particular piece of code, while this PR aims to resolve the root cause globally.

## Description
<!-- Goal of the pull request -->

This disables loose transformations in babel, to avoid inconsistencies between different environments.

In particular, this code is transpiled differently  in dev and prod when `loose` is enabled:

```
[...Array(numberStochasticRuns).keys()]
```

Additionally, this disables "shipped proposals", just in case, as it is a risky option too.

See also: 
 - https://babeljs.io/docs/en/babel-plugin-transform-spread#loose
 - https://github.com/babel/babel-preset-env/issues/76
 - https://babeljs.io/docs/en/babel-preset-env#loose


## Impacted Areas in the application
<!-- Components of the application that this PR will change -->

Build, transpilation.

## Testing
<!-- Steps to test the changes proposed by this PR -->
