### PR TITLE
Feat/weekly deaths

### DIFF
--- a/src/algorithms/preparePlotData.ts
+++ b/src/algorithms/preparePlotData.ts
@@ -15,6 +15,7 @@ export function preparePlotData(trajectory: Trajectory): PlotDatum[] {
       overflow: verifyPositive(x.current.overflow.total),
       recovered: verifyPositive(x.cumulative.recovered.total),
       fatality: verifyPositive(x.cumulative.fatality.total),
+      weeklyFatality: verifyPositive(x.cumulative.fatality.total - middle[i > 6 ? i - 7 : 0].cumulative.fatality.total),
     },
     // Error bars
     areas: {
@@ -45,6 +46,13 @@ export function preparePlotData(trajectory: Trajectory): PlotDatum[] {
       fatality: verifyTuple(
         [verifyPositive(lower[i].cumulative.fatality.total), verifyPositive(upper[i].cumulative.fatality.total)],
         x.cumulative.fatality.total,
+      ),
+      weeklyFatality: verifyTuple(
+        [
+          verifyPositive(lower[i].cumulative.fatality.total - middle[i > 6 ? i - 7 : 0].cumulative.fatality.total),
+          verifyPositive(upper[i].cumulative.fatality.total - middle[i > 6 ? i - 7 : 0].cumulative.fatality.total),
+        ],
+        x.cumulative.fatality.total - middle[i > 6 ? i - 7 : 0].cumulative.fatality.total,
       ),
     },
   }))

--- a/src/components/Main/Results/ChartCommon.ts
+++ b/src/components/Main/Results/ChartCommon.ts
@@ -116,14 +116,14 @@ export const areasToPlot: LineProps[] = [
   },
 ]
 
-export function observationsToPlot(casesDelta: number): LineProps[] {
+export function observationsToPlot(): LineProps[] {
   return [
     { key: DATA_POINTS.ObservedCases, color: colors.cumulativeCases, name: 'Cumulative cases (data)' },
-    { key: DATA_POINTS.ObservedNewCases, color: colors.newCases, name: `Cases past ${casesDelta} day(s) (data)` },
+    { key: DATA_POINTS.ObservedNewCases, color: colors.newCases, name: `Weekly cases (data)` },
     { key: DATA_POINTS.ObservedHospitalized, color: colors.severe, name: 'Patients in hospital (data)' },
     { key: DATA_POINTS.ObservedICU, color: colors.critical, name: 'Patients in ICU (data)' },
     { key: DATA_POINTS.ObservedDeaths, color: colors.fatality, name: 'Cumulative deaths (data)' },
-    { key: DATA_POINTS.ObservedWeeklyDeaths, color: colors.weeklyFatality, name: 'weekly deaths (data)' },
+    { key: DATA_POINTS.ObservedWeeklyDeaths, color: colors.weeklyFatality, name: 'Weekly deaths (data)' },
   ]
 }
 

--- a/src/components/Main/Results/ChartCommon.ts
+++ b/src/components/Main/Results/ChartCommon.ts
@@ -18,6 +18,7 @@ export const DATA_POINTS = {
   Overflow: 'overflow',
   Recovered: 'recovered',
   Fatalities: 'fatality',
+  WeeklyFatalities: 'weeklyFatality',
   CumulativeCases: 'cumulativeCases',
   NewCases: 'newCases',
   HospitalBeds: 'hospitalBeds',
@@ -28,6 +29,7 @@ export const DATA_POINTS = {
   ObservedHospitalized: 'currentHospitalized',
   ObservedICU: 'ICU',
   ObservedNewCases: 'newCases',
+  ObservedWeeklyDeaths: 'weeklyDeaths',
 }
 
 export const colors = {
@@ -38,6 +40,7 @@ export const colors = {
   [DATA_POINTS.Overflow]: '#900d2c',
   [DATA_POINTS.Recovered]: '#33a02c',
   [DATA_POINTS.Fatalities]: '#5e506a',
+  [DATA_POINTS.WeeklyFatalities]: '#5e505a',
   [DATA_POINTS.CumulativeCases]: '#aaaaaa',
   [DATA_POINTS.NewCases]: '#fdbf6f',
   [DATA_POINTS.HospitalBeds]: '#bbbbbb',
@@ -52,6 +55,12 @@ export const linesToPlot: LineProps[] = [
   { key: DATA_POINTS.Critical, color: colors.critical, name: 'Patients in ICU (model)', legendType: 'line' },
   { key: DATA_POINTS.Overflow, color: colors.overflow, name: 'ICU overflow', legendType: 'line' },
   { key: DATA_POINTS.Fatalities, color: colors.fatality, name: 'Cumulative deaths (model)', legendType: 'line' },
+  {
+    key: DATA_POINTS.WeeklyFatalities,
+    color: colors.weeklyFatality,
+    name: 'weekly deaths (model)',
+    legendType: 'line',
+  },
   { key: DATA_POINTS.HospitalBeds, color: colors.hospitalBeds, name: 'Total hospital beds', legendType: 'none' },
   { key: DATA_POINTS.ICUbeds, color: colors.ICUbeds, name: 'Total ICU/ICM beds', legendType: 'none' },
 ]
@@ -99,6 +108,12 @@ export const areasToPlot: LineProps[] = [
     name: 'Cumulative deaths (model) uncertainty',
     legendType: 'none',
   },
+  {
+    key: `${DATA_POINTS.WeeklyFatalities}Area`,
+    color: colors.weeklyFatality,
+    name: 'Weekly deaths (model) uncertainty',
+    legendType: 'none',
+  },
 ]
 
 export function observationsToPlot(casesDelta: number): LineProps[] {
@@ -108,6 +123,7 @@ export function observationsToPlot(casesDelta: number): LineProps[] {
     { key: DATA_POINTS.ObservedHospitalized, color: colors.severe, name: 'Patients in hospital (data)' },
     { key: DATA_POINTS.ObservedICU, color: colors.critical, name: 'Patients in ICU (data)' },
     { key: DATA_POINTS.ObservedDeaths, color: colors.fatality, name: 'Cumulative deaths (data)' },
+    { key: DATA_POINTS.ObservedWeeklyDeaths, color: colors.weeklyFatality, name: 'weekly deaths (data)' },
   ]
 }
 

--- a/src/components/Main/Results/DeterministicLinePlot.tsx
+++ b/src/components/Main/Results/DeterministicLinePlot.tsx
@@ -104,14 +104,18 @@ export function DeterministicLinePlotDiconnected({
   const nICUBeds = verifyPositive(scenarioData.population.icuBeds)
 
   const [newEmpiricalCases, caseTimeWindow] = computeNewEmpiricalCases(
-    scenarioData.epidemiological.infectiousPeriodDays,
+    7, //scenarioData.epidemiological.infectiousPeriodDays,
+    'cases',
     caseCountsData,
   )
+
+  const [weeklyEmpiricalDeaths, deathsTimeWindow] = computeNewEmpiricalCases(7, 'deaths', caseCountsData)
 
   const hasObservations = {
     [DATA_POINTS.ObservedCases]: caseCountsData && caseCountsData.some((d) => d.cases),
     [DATA_POINTS.ObservedICU]: caseCountsData && caseCountsData.some((d) => d.icu),
     [DATA_POINTS.ObservedDeaths]: caseCountsData && caseCountsData.some((d) => d.deaths),
+    [DATA_POINTS.ObservedWeeklyDeaths]: caseCountsData && caseCountsData.some((d) => d.deaths),
     [DATA_POINTS.ObservedNewCases]: newEmpiricalCases && newEmpiricalCases.some((d) => d),
     [DATA_POINTS.ObservedHospitalized]: caseCountsData && caseCountsData.some((d) => d.hospitalized),
   }
@@ -126,10 +130,11 @@ export function DeterministicLinePlotDiconnected({
         : undefined,
       ICU: enabledPlots.includes(DATA_POINTS.ObservedICU) ? d.icu || undefined : undefined,
       newCases: enabledPlots.includes(DATA_POINTS.ObservedNewCases) ? newEmpiricalCases[i] : undefined,
+      weeklyDeaths: enabledPlots.includes(DATA_POINTS.ObservedWeeklyDeaths) ? weeklyEmpiricalDeaths[i] : undefined,
       hospitalBeds: nHospitalBeds,
       ICUbeds: nICUBeds,
     })) ?? []
-
+  console.log(observations)
   const plotData = [
     ...result.plotData.map((x) => {
       const dpoint = { time: x.time, hospitalBeds: nHospitalBeds, ICUbeds: nICUBeds }

--- a/src/components/Main/Results/DeterministicLinePlot.tsx
+++ b/src/components/Main/Results/DeterministicLinePlot.tsx
@@ -134,7 +134,7 @@ export function DeterministicLinePlotDiconnected({
       hospitalBeds: nHospitalBeds,
       ICUbeds: nICUBeds,
     })) ?? []
-  console.log(observations)
+
   const plotData = [
     ...result.plotData.map((x) => {
       const dpoint = { time: x.time, hospitalBeds: nHospitalBeds, ICUbeds: nICUBeds }
@@ -175,7 +175,7 @@ export function DeterministicLinePlotDiconnected({
   const tMin = _.minBy(plotData, 'time')!.time // eslint-disable-line @typescript-eslint/no-non-null-assertion
   const tMax = _.maxBy(plotData, 'time')!.time // eslint-disable-line @typescript-eslint/no-non-null-assertion
 
-  const observationsHavingDataToPlot = observationsToPlot(caseTimeWindow).filter((itemToPlot) => {
+  const observationsHavingDataToPlot = observationsToPlot().filter((itemToPlot) => {
     if (observations.length !== 0) {
       return hasObservations[itemToPlot.key]
     }

--- a/src/components/Main/Results/Utils.ts
+++ b/src/components/Main/Results/Utils.ts
@@ -27,6 +27,7 @@ export function verifyTuple(x: [maybeNumber, maybeNumber], center: maybeNumber):
 
 export function computeNewEmpiricalCases(
   timeWindow: number,
+  field: string,
   cumulativeCounts?: CaseCountsDatum[],
 ): [maybeNumber[], number] {
   const newEmpiricalCases: maybeNumber[] = []
@@ -46,18 +47,17 @@ export function computeNewEmpiricalCases(
     const startDay = day - deltaDay
     const startDayPlus = day - deltaDay - 1
 
-    const nowCases = cumulativeCounts[day].cases
-    const oldCases = cumulativeCounts[startDay].cases
-    const olderCases = cumulativeCounts[startDayPlus]?.cases
+    const nowCases = cumulativeCounts[day][field]
+    const oldCases = cumulativeCounts[startDay][field]
+    const olderCases = cumulativeCounts[startDayPlus] ? cumulativeCounts[startDayPlus][field] : undefined
     if (oldCases && nowCases) {
       const newCases = verifyPositive(
         olderCases ? (1 - deltaInt) * (nowCases - oldCases) + deltaInt * (nowCases - olderCases) : nowCases - oldCases,
       )
-      newEmpiricalCases.push(newCases)
+      newEmpiricalCases[day] = newCases
       return
     }
     newEmpiricalCases[day] = undefined
   })
-
   return [newEmpiricalCases, deltaDay]
 }


### PR DESCRIPTION
## Description
As we progress further into the pandemic, total deaths are not very useful to assess current trends. This PR adds weekly deaths to the graph and also changes the interval for cases to weekly. This has the benefit of smoothing out weekday variation. Need to adjust colors. 

## Impacted Areas in the application
plot and plotdata preparation. 


## Testing
do we like it?
