### PR TITLE
fix: adjust getPopulationData.py to account for input file change

### DIFF
--- a/data/scripts/getPopulationData.py
+++ b/data/scripts/getPopulationData.py
@@ -109,12 +109,12 @@ def update_cia_facts(hospData, popData):
     return hospData, popData
 
 def check_if_age(country):
-    PATH_UN_AGES   = "../src/assets/data/country_age_distribution.json"
+    PATH_UN_AGES   = "../src/assets/data/ageDistribution.json"
 
     with open(PATH_UN_AGES, 'r') as f:
         ages = json.load(f)
 
-    return country in [x['country'] for x in ages]
+    return country in [x["name"] for x in ages["all"]]
     
 
 def update_hosp_data(hospData, popData):


### PR DESCRIPTION
## Related issues and PRs

##  Description
Was unable to run `python generate_data.py --output-population ../src/assets/data/population.json` due to a name change of a hard-coded path in the script and a change made to the structure of an input json file. 

Error for file path: 

`No such file or directory: '../src/assets/data/country_age_distribution.json'`

Error for json structure change: 

`return country in [x['country'] for x in ages] `
`TypeError: string indices must be integers`

## Impacted Areas in the application

Updating population data

## Testing
`python generate_data.py --output-population test.json`
