### PR TITLE
fix: fix crash when navigating to a page

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "file-saver": "2.0.2",
     "flag-icon-css": "3.5.0",
     "formik": "2.1.5",
-    "history": "5.0.0",
+    "history": "4.10.1",
     "i18next": "19.6.2",
     "i18next-browser-languagedetector": "5.0.0",
     "immer": "7.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9270,14 +9270,7 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
-history@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/history/-/history-5.0.0.tgz#0cabbb6c4bbf835addb874f8259f6d25101efd08"
-  integrity sha512-3NyRMKIiFSJmIPdq7FxkNMJkQ7ZEtVblOQ38VtKaA0zZMW1Eo6Q6W8oDKEflr1kNNTItSnk4JMCO1deeSgbLLg==
-  dependencies:
-    "@babel/runtime" "^7.7.6"
-
-history@^4.9.0:
+history@4.10.1, history@^4.9.0:
   version "4.10.1"
   resolved "https://registry.yarnpkg.com/history/-/history-4.10.1.tgz#33371a65e3a83b267434e2b3f3b1b4c58aad4cf3"
   integrity sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==


### PR DESCRIPTION
This was due to the upgrade of the `history` package in #762. History v5 is not compatible with our setup.
