### PR TITLE
fix: load scenario json from older versions

### DIFF
--- a/src/io/serialization/v2.0.0/serialize.ts
+++ b/src/io/serialization/v2.0.0/serialize.ts
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-import { trim } from 'lodash'
+import { set, trim } from 'lodash'
 
 import Ajv from 'ajv'
 import ajvLocalizers from 'ajv-i18n'
@@ -67,6 +67,8 @@ function deserialize(input: string) {
       data: shareable.severityDistributionData.data.map((severity) => ({ ...severity, palliative: 0 })),
     },
   }
+
+  set(shareable, 'schemaVer', schemaVerNext)
 
   // Delegate to the next version of deserializer
   return v2_1_0[schemaVerNext].deserialize(JSON.stringify(shareableNew))

--- a/src/io/serialization/v2.1.0/serialize.ts
+++ b/src/io/serialization/v2.1.0/serialize.ts
@@ -61,6 +61,7 @@ function deserialize(input: string): ScenarioParameters {
   // Migrate object to schema v2.2.0:
   //  - Add seroprevalence and set it to 0
   set(shareable.scenarioData.data.population, 'seroprevalence', 0)
+  set(shareable, 'schemaVer', schemaVerNext)
 
   // Delegate to the next version of deserializer
   return v2_2_0[schemaVerNext].deserialize(JSON.stringify(shareable))


### PR DESCRIPTION
This fixes an error "/schemaVer should be equal to constant" when dropping a  JSON file with schemaVer < 2.2.0 in scenario loader.
